### PR TITLE
perf(ai-experiences): strip topic-gate embeddings from list response

### DIFF
--- a/backend/src/features/ai-experience/ai-experience.service.test.ts
+++ b/backend/src/features/ai-experience/ai-experience.service.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// The service pulls in the repository (and through it, the DB). Mock the
+// repository so these are pure, DB-free unit tests of the service's response
+// shaping.
+vi.mock('./ai-experience.repository', () => ({
+  listAIExperiences: vi.fn(),
+}));
+
+import * as repository from './ai-experience.repository';
+import { listAIExperiences } from './ai-experience.service';
+import type { ListAIExperiencesQuery } from './ai-experience.types';
+
+const QUERY: ListAIExperiencesQuery = {
+  page: 1,
+  pageSize: 25,
+  sortBy: 'createdAt',
+  sortOrder: 'desc',
+};
+
+function experienceWithTopicGate() {
+  return {
+    id: 'exp-1',
+    slug: 'support',
+    name: 'Support',
+    guardrailConfig: {
+      inputGuardrail: {
+        enabled: true,
+        onBlock: { message: 'blocked' },
+        rules: [
+          {
+            type: 'topic_gate',
+            enabled: true,
+            config: {
+              allowedDomains: ['billing'],
+              expandedTerms: ['invoice', 'refund'],
+              termEmbeddings: [
+                [0.1, 0.2, 0.3],
+                [0.4, 0.5, 0.6],
+              ],
+              generalTerms: ['weather'],
+              generalTermEmbeddings: [[0.7, 0.8, 0.9]],
+              threshold: 0.5,
+            },
+          },
+        ],
+      },
+      outputGuardrail: {
+        enabled: false,
+        onBlock: { message: 'blocked' },
+        rules: [],
+      },
+    },
+  };
+}
+
+describe('listAIExperiences (service)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('strips topic-gate embedding vectors from the list response', async () => {
+    vi.mocked(repository.listAIExperiences).mockResolvedValue({
+      experiences: [experienceWithTopicGate()] as any,
+      pagination: { page: 1, pageSize: 25, totalItems: 1, totalPages: 1 },
+    });
+
+    const { experiences } = await listAIExperiences(QUERY);
+    const ruleConfig = (experiences[0] as any).guardrailConfig.inputGuardrail.rules[0].config;
+
+    // The byte-heavy embedding arrays are gone...
+    expect(ruleConfig.termEmbeddings).toBeUndefined();
+    expect(ruleConfig.generalTermEmbeddings).toBeUndefined();
+    // ...but everything else the list/editor needs survives.
+    expect(ruleConfig.expandedTerms).toEqual(['invoice', 'refund']);
+    expect(ruleConfig.generalTerms).toEqual(['weather']);
+    expect(ruleConfig.allowedDomains).toEqual(['billing']);
+    expect(ruleConfig.threshold).toBe(0.5);
+  });
+
+  it('does not mutate the original repository result', async () => {
+    const source = experienceWithTopicGate();
+    vi.mocked(repository.listAIExperiences).mockResolvedValue({
+      experiences: [source] as any,
+      pagination: { page: 1, pageSize: 25, totalItems: 1, totalPages: 1 },
+    });
+
+    await listAIExperiences(QUERY);
+
+    // Detail/by-id/slug fetches share this row shape and must keep embeddings.
+    expect(source.guardrailConfig.inputGuardrail.rules[0].config.termEmbeddings).toHaveLength(2);
+  });
+
+  it('passes through experiences with no guardrailConfig', async () => {
+    vi.mocked(repository.listAIExperiences).mockResolvedValue({
+      experiences: [{ id: 'exp-2', slug: 'x', name: 'X', guardrailConfig: null }] as any,
+      pagination: { page: 1, pageSize: 25, totalItems: 1, totalPages: 1 },
+    });
+
+    const { experiences } = await listAIExperiences(QUERY);
+    expect((experiences[0] as any).guardrailConfig).toBeNull();
+  });
+});

--- a/backend/src/features/ai-experience/ai-experience.service.ts
+++ b/backend/src/features/ai-experience/ai-experience.service.ts
@@ -32,6 +32,44 @@ async function clearDetailCache(_id: string, _slug: string) {
   await cache.clear();
 }
 
+/**
+ * Strip topic-gate embedding vectors from a guardrailConfig for list responses.
+ *
+ * Topic-gate rules persist `termEmbeddings`/`generalTermEmbeddings` (number[][])
+ * inline in the rule config. These run into hundreds of KB per experience and are
+ * only needed at runtime (loaded via the by-slug/by-id fetch into the topic-gate
+ * cache) or in the detail editor. The list view never reads them, so returning
+ * them bloated the list response to ~460 KB/row (11.5 MB for a default page of 25).
+ * Returns a shallow copy with the embedding arrays removed; original is untouched.
+ */
+function stripGuardrailEmbeddings<T>(guardrailConfig: T): T {
+  const config = guardrailConfig as Record<string, unknown> | null;
+  if (!config) return guardrailConfig;
+
+  const stripRules = (guardrail: unknown) => {
+    const g = guardrail as { rules?: Array<Record<string, unknown>> } | undefined;
+    if (!g?.rules?.length) return guardrail;
+    return {
+      ...g,
+      rules: g.rules.map((rule) => {
+        const ruleConfig = rule.config as Record<string, unknown> | undefined;
+        if (!ruleConfig) return rule;
+        const { termEmbeddings, generalTermEmbeddings, ...rest } = ruleConfig;
+        // Touch the destructured fields so lint doesn't flag them as unused.
+        void termEmbeddings;
+        void generalTermEmbeddings;
+        return { ...rule, config: rest };
+      }),
+    };
+  };
+
+  return {
+    ...config,
+    inputGuardrail: stripRules(config.inputGuardrail),
+    outputGuardrail: stripRules(config.outputGuardrail),
+  } as T;
+}
+
 // ============================================================================
 // CRUD OPERATIONS
 // ============================================================================
@@ -117,7 +155,10 @@ export async function getAIExperienceByAccessToken(accessToken: string) {
 export async function listAIExperiences(query: ListAIExperiencesQuery): Promise<AIExperienceListResponse> {
   const result = await repository.listAIExperiences(query);
   return {
-    experiences: result.experiences as any[],
+    experiences: result.experiences.map((experience) => ({
+      ...experience,
+      guardrailConfig: stripGuardrailEmbeddings(experience.guardrailConfig),
+    })) as any[],
     pagination: result.pagination,
   };
 }


### PR DESCRIPTION
The AI experiences list endpoint serialized full guardrailConfig per row, including topic-gate termEmbeddings/generalTermEmbeddings (number[][]). At ~460 KB/row this ballooned a default page (25) to 11.5 MB and ~13s wall time, dominated by serialization + transfer rather than DB query time.

Embeddings are only needed at runtime (loaded via the by-slug/by-id fetch into the topic-gate cache) and in the detail editor (by-id fetch). The list view never reads them, so strip them in the list shaping layer. Detail/by-id/slug fetches are untouched and still return full config.