### PR TITLE
docs: align branch references with single-trunk migration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # CODEOWNERS for Interakt
 # ------------------------------------------------------------------
 # This file defines who is automatically requested for review on PRs.
-# Combined with the "require_code_owner_review" rule on main/develop,
+# Combined with the "require_code_owner_review" rule on main,
 # it ensures no PR merges without a maintainer's approval.
 #
 # Rules:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ to a feature, match the surrounding structure rather than introducing a new patt
 
 ## Development workflow
 
-1. Branch from `develop` (the default branch): `git checkout -b feature/your-change`.
+1. Branch from `main` (the default branch): `git checkout -b feature/your-change`.
 2. Make your change. Add or update tests for any non-trivial logic (see below).
 3. Run the full local check before opening a PR:
 
@@ -57,7 +57,7 @@ to a feature, match the surrounding structure rather than introducing a new patt
    ```
 
    If you touched `backend/widgets/`, also run `npm --prefix widgets run build && npm --prefix widgets test`.
-4. Open a PR against `develop`. CI (lint · type-check · test, for both backend and widgets)
+4. Open a PR against `main`. CI (lint · type-check · test, for both backend and widgets)
    must pass.
 
 ## Database changes

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,7 +29,7 @@ proof of concept, the affected endpoint or component, and any relevant configura
 ## Supported versions
 
 Interakt is in active early development (0.x). Security fixes are applied to the latest
-`develop` and `main`; there are no long-term support branches for older revisions yet.
+`main`; there are no long-term support branches for older revisions yet.
 
 ## Scope and hardening notes
 


### PR DESCRIPTION
## What
Fixes docs and config that still reference the retired `develop` branch.

- **CONTRIBUTING.md** — branch from / open PRs against `main` (was `develop`)
- **SECURITY.md** — security fixes apply to the latest `main` (was `develop` and `main`)
- **.github/CODEOWNERS** — drop `develop` from the rule comment

## Why
When the project went open source it moved to a single trunk (`main`); `develop`/`dev` were retired. These docs were the first thing a new contributor reads, and they pointed at a branch that no longer exists.

## Testing
Docs/comment-only — no code or behavior change. CI (lint · type-check · test) should pass unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)