### PR TITLE
Generic document browse, query understanding, and reindex fixes

### DIFF
--- a/backend/db/schema/search-experience.schema.ts
+++ b/backend/db/schema/search-experience.schema.ts
@@ -128,6 +128,30 @@ export interface SearchExperienceAISummaryConfig {
 }
 
 /**
+ * Natural-language query understanding settings.
+ *
+ * When enabled, a search query is parsed into a cleaned query plus structured
+ * filters before searching — "men's t-shirts below $110" becomes
+ * `t-shirts` + `gender=Men` + `minPrice<=110`.
+ *
+ * Off by default. It adds an LLM call to the search path, which costs latency and
+ * money on every query, so it is a deliberate choice per experience rather than
+ * something existing search boxes silently inherit.
+ */
+export interface SearchExperienceQueryUnderstandingConfig {
+  /** Enable natural-language filter extraction */
+  enabled: boolean;
+  /**
+   * Skip interpretation for queries shorter than this many words. A one- or
+   * two-word lookup like "sweatshirt" has no filters to find and should not pay
+   * for an LLM round trip.
+   */
+  minWords: number;
+  /** Extra guidance appended to the interpreter instructions */
+  customInstructions?: string;
+}
+
+/**
  * AI configuration settings
  */
 export interface SearchExperienceAIConfig {
@@ -139,6 +163,11 @@ export interface SearchExperienceAIConfig {
   modelId: number | null;
   /** Summary generation settings */
   summary: SearchExperienceAISummaryConfig;
+  /**
+   * Natural-language query understanding. Optional so experiences created before
+   * this feature existed keep working — treat a missing value as disabled.
+   */
+  queryUnderstanding?: SearchExperienceQueryUnderstandingConfig;
 }
 
 /**

--- a/backend/src/app/api/v1/search/[slug]/search/route.ts
+++ b/backend/src/app/api/v1/search/[slug]/search/route.ts
@@ -19,6 +19,8 @@ import type { SearchRequest, SearchResponse, FacetResult, FacetType } from '@/fe
 import { SearchError } from '@/features/search/search.types';
 import * as repository from '@/features/search-experience/search-experience.repository';
 import { publicSearchRequestSchema } from '@/features/search-experience/search-experience.schemas';
+import { applyQueryInterpretation } from '@/features/search-experience/query-interpreter';
+import type { QueryInterpretation } from '@/features/search-experience/query-interpreter';
 import type {
   SearchExperienceWithIndexes,
   SearchExperienceIndex,
@@ -108,7 +110,11 @@ export async function POST(
     }
 
     // 5. Build search request
-    const searchRequest = buildSearchRequest(validated, experience);
+    const { request: searchRequest, interpretation } = await buildSearchRequest(
+      validated,
+      experience,
+      indexesToSearch[0]?.searchIndexId
+    );
 
     // 6. Execute search (pass experience for hybrid config)
     const results = await executeMultiIndexSearch(indexesToSearch, searchRequest, experience);
@@ -116,6 +122,15 @@ export async function POST(
     // 7. Transform results for response
     const response = {
       query: validated.query,
+      // What the phrase was understood to mean, so a client can show it (and let
+      // the user undo it). Absent when interpretation is off or was skipped.
+      ...(interpretation?.interpreted && {
+        interpretation: {
+          effectiveQuery: interpretation.effectiveQuery,
+          appliedFilters: interpretation.appliedFilters,
+          droppedFilters: interpretation.droppedFilters,
+        },
+      }),
       results: results.hits.map((hit) => ({
         id: hit.id,
         index: {
@@ -174,12 +189,26 @@ function resolveIndexesToSearch(
   return activeIndexes;
 }
 
-function buildSearchRequest(
+async function buildSearchRequest(
   input: PlaygroundSearchRequest,
-  experience: SearchExperienceWithIndexes
-): SearchRequest {
+  experience: SearchExperienceWithIndexes,
+  primarySearchIndexId: string | undefined
+): Promise<{ request: SearchRequest; interpretation?: QueryInterpretation }> {
   const searchConfig = experience.searchConfig;
-  const filters = input.filters as SearchRequest['filters'];
+
+  // Natural-language understanding: turn "men's t-shirts below $110" into a clean
+  // query plus real filters before searching. No-op unless the experience opts in.
+  const interpreted = await applyQueryInterpretation({
+    query: input.query,
+    clientFilters: input.filters as Array<{ field: string; operator: string; value: unknown }> | undefined,
+    searchIndexId: primarySearchIndexId,
+    config: experience.aiConfig?.queryUnderstanding,
+    providerId: experience.aiConfig?.providerId,
+    modelId: experience.aiConfig?.modelId,
+    experienceId: experience.id,
+  });
+
+  const filters = interpreted.filters as SearchRequest['filters'];
   const facets = input.facets?.map((f: { field: string; type?: string; size?: number }) => ({
     field: f.field,
     type: (f.type ?? 'terms') as 'terms' | 'range' | 'date_range' | 'date_histogram' | 'histogram',
@@ -197,8 +226,8 @@ function buildSearchRequest(
     ? input.searchType
     : (searchConfig.defaultSearchType ?? 'auto');
 
-  return {
-    query: input.query,
+  const request: SearchRequest = {
+    query: interpreted.query,
     searchType,
     filters,
     facets,
@@ -214,6 +243,8 @@ function buildSearchRequest(
       ? { preTag: '<em>', postTag: '</em>' }
       : undefined,
   };
+
+  return { request, interpretation: interpreted.interpretation };
 }
 
 async function executeMultiIndexSearch(

--- a/backend/src/app/search-indexes/_components/DocumentManager/DocumentManagerPanel.tsx
+++ b/backend/src/app/search-indexes/_components/DocumentManager/DocumentManagerPanel.tsx
@@ -49,6 +49,8 @@ import {
     ChevronRight,
     ChevronDown,
     ChevronLeft,
+    Check,
+    X,
 } from 'lucide-react';
 import { toast } from 'sonner';
 import {
@@ -121,6 +123,149 @@ function formatCellValue(value: unknown): string {
     return String(value);
 }
 
+/** Stop a link or control inside a row from also toggling the row's expansion. */
+function stopRowToggle(event: React.MouseEvent) {
+    event.stopPropagation();
+}
+
+/**
+ * Format a date value for a table cell, keeping the exact value in the tooltip.
+ *
+ * Anything unparseable falls back to the raw string — a malformed date in an index
+ * is worth seeing verbatim, not hiding behind "Invalid Date".
+ */
+function formatDateCell(value: unknown): { text: string; title: string } {
+    const raw = String(value);
+    const parsed = new Date(raw);
+    if (Number.isNaN(parsed.getTime())) {
+        return { text: raw, title: raw };
+    }
+    return { text: parsed.toLocaleString(), title: raw };
+}
+
+/**
+ * Summarise an array in one cell: a couple of primitive values, or a count.
+ *
+ * A tags array is worth reading inline; an array of objects is not, so it
+ * collapses to "N items" and leaves the detail to the expanded row.
+ */
+function summariseArray(values: unknown[]): string {
+    if (values.length === 0) return 'empty';
+    if (values.some(entry => entry !== null && typeof entry === 'object')) {
+        return `${values.length} item${values.length === 1 ? '' : 's'}`;
+    }
+    const shown = values.slice(0, 2).map(String).join(', ');
+    return values.length > 2 ? `${shown} +${values.length - 2}` : shown;
+}
+
+/**
+ * A document's image field as a thumbnail, falling back to the URL text.
+ *
+ * A broken image icon says nothing useful about the document; the URL that failed
+ * to load is exactly what someone inspecting a bad document needs to see.
+ */
+function ThumbnailCell({ url }: { url: string }) {
+    const [failed, setFailed] = useState(false);
+
+    if (failed) {
+        return <span className="text-xs text-muted-foreground" title={url}>{url}</span>;
+    }
+
+    return (
+        // next/image is not usable here: document image URLs point at arbitrary
+        // remote hosts and next.config declares no images.remotePatterns.
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+            src={url}
+            alt=""
+            title={url}
+            className="h-8 w-8 rounded border object-cover"
+            onError={() => setFailed(true)}
+        />
+    );
+}
+
+/**
+ * Render one document field according to its declared type.
+ *
+ * The index already knows what each field holds, so a cell can show a thumbnail,
+ * a followable link or a formatted date instead of a stringified value. Cells are
+ * summaries by design — the expanded row still shows the raw document, so
+ * anything collapsed here is one click from being seen in full.
+ */
+function DocumentCell({
+    value,
+    type,
+}: {
+    value: unknown;
+    type: DocumentColumnDescriptor['type'];
+}) {
+    if (value === null || value === undefined || value === '') {
+        return <span className="text-muted-foreground">—</span>;
+    }
+
+    switch (type) {
+        case 'boolean': {
+            const truthy = value === true || value === 'true';
+            return truthy
+                ? <Check className="h-4 w-4 text-emerald-600" aria-label="true" />
+                : <X className="h-4 w-4 text-muted-foreground" aria-label="false" />;
+        }
+
+        case 'number': {
+            const numeric = typeof value === 'number' ? value : Number(value);
+            return (
+                <span className="tabular-nums">
+                    {Number.isNaN(numeric) ? String(value) : numeric.toLocaleString()}
+                </span>
+            );
+        }
+
+        case 'date':
+        case 'datetime': {
+            const { text, title } = formatDateCell(value);
+            return <span className="whitespace-nowrap" title={title}>{text}</span>;
+        }
+
+        case 'image_url':
+            return <ThumbnailCell url={String(value)} />;
+
+        case 'url':
+        case 'email': {
+            const href = type === 'email' ? `mailto:${String(value)}` : String(value);
+            return (
+                <a
+                    href={href}
+                    target={type === 'url' ? '_blank' : undefined}
+                    rel={type === 'url' ? 'noreferrer' : undefined}
+                    onClick={stopRowToggle}
+                    className="text-primary underline-offset-2 hover:underline"
+                    title={String(value)}
+                >
+                    {String(value)}
+                </a>
+            );
+        }
+
+        case 'array':
+            return (
+                <Badge variant="secondary" className="font-normal" title={JSON.stringify(value)}>
+                    {Array.isArray(value) ? summariseArray(value) : formatCellValue(value)}
+                </Badge>
+            );
+
+        case 'json':
+            return (
+                <Badge variant="secondary" className="font-normal" title={JSON.stringify(value)}>
+                    {'{…}'}
+                </Badge>
+            );
+
+        default:
+            return <span title={formatCellValue(value)}>{formatCellValue(value)}</span>;
+    }
+}
+
 /**
  * A document table shared by the browse card and the delete-by-filter preview,
  * so both present documents the same way.
@@ -187,7 +332,12 @@ function DocumentTable({
                                         >
                                             {columnIndex === 0
                                                 ? document.id
-                                                : formatCellValue(document.fields[column.field])}
+                                                : (
+                                                    <DocumentCell
+                                                        value={document.fields[column.field]}
+                                                        type={column.type}
+                                                    />
+                                                )}
                                         </TableCell>
                                     ))}
                                 </TableRow>

--- a/backend/src/app/search-indexes/_components/DocumentManager/DocumentManagerPanel.tsx
+++ b/backend/src/app/search-indexes/_components/DocumentManager/DocumentManagerPanel.tsx
@@ -51,6 +51,7 @@ import {
     ChevronLeft,
     Check,
     X,
+    Sparkles,
 } from 'lucide-react';
 import { toast } from 'sonner';
 import {
@@ -63,6 +64,7 @@ import {
 import type {
     DocumentColumnDescriptor,
     DocumentSummary,
+    EmbeddingPreview,
 } from '../../_lib/api-client';
 
 // ============================================================================
@@ -537,6 +539,79 @@ function BrowseDocuments({ searchIndexId }: { searchIndexId: string }) {
     );
 }
 
+/**
+ * Why a field contributed nothing, in words — the three causes have three
+ * different fixes, so they must not read the same.
+ */
+const EXCLUSION_HINTS: Record<string, string> = {
+    missing: 'No value on this document — check the ingest data or the field mapping',
+    empty: 'A value exists but is blank, e.g. an empty list',
+    'unsupported-type': 'Objects and lists of objects cannot be embedded — this field will never contribute',
+};
+
+/**
+ * Show exactly the text this document's vector was built from.
+ *
+ * The stored vector is stripped from every read and a bad one is
+ * indistinguishable from a good one, so the text is the only visible evidence of
+ * why a document does or does not match semantically. Excluded fields are listed
+ * rather than hidden: a vector-source field contributing nothing — a json blob,
+ * an empty array — is exactly the kind of thing that quietly ruins a result set.
+ */
+function EmbeddingPreviewPanel({ preview }: { preview: EmbeddingPreview }) {
+    const included = preview.parts.filter(part => part.included);
+    const excluded = preview.parts.filter(part => !part.included);
+
+    return (
+        <div className="space-y-3 rounded-md border p-4">
+            <div className="flex flex-wrap items-center gap-2">
+                <Sparkles className="h-4 w-4 text-violet-500" />
+                <span className="text-sm font-medium">Embedded text</span>
+                <Badge variant="secondary" className="font-normal">
+                    {preview.totalChars.toLocaleString()} chars
+                </Badge>
+                <Badge variant="secondary" className="font-normal">
+                    {included.length} of {preview.parts.length} fields
+                </Badge>
+            </div>
+
+            <p className="text-xs text-muted-foreground">
+                This exact string was sent to the embedding model. Fields appear in
+                boost order — earlier text carries more weight.
+            </p>
+
+            <ScrollArea className="h-56 rounded-md border bg-muted/30">
+                <pre className="whitespace-pre-wrap break-words p-4 text-xs">
+                    {preview.text || '(empty — this document has no vector)'}
+                </pre>
+            </ScrollArea>
+
+            {excluded.length > 0 && (
+                <div className="space-y-1">
+                    <p className="text-xs font-medium text-muted-foreground">
+                        Contributing nothing
+                    </p>
+                    <div className="flex flex-wrap gap-1.5">
+                        {excluded.map(part => (
+                            <Badge
+                                key={part.fieldName}
+                                variant="outline"
+                                className="font-normal text-xs"
+                                title={EXCLUSION_HINTS[part.excludedBecause ?? 'missing']}
+                            >
+                                {part.label}
+                                <span className="ml-1 text-muted-foreground">
+                                    {part.excludedBecause}
+                                </span>
+                            </Badge>
+                        ))}
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}
+
 function DocumentLookup({ searchIndexId }: { searchIndexId: string }) {
     const [inputValue, setInputValue] = useState('');
     // Only set once the user submits, so we don't fetch on every keystroke
@@ -633,6 +708,10 @@ function DocumentLookup({ searchIndexId }: { searchIndexId: string }) {
                                 {JSON.stringify(data.document, null, 2)}
                             </pre>
                         </ScrollArea>
+
+                        {data.embeddingPreview && (
+                            <EmbeddingPreviewPanel preview={data.embeddingPreview} />
+                        )}
                     </div>
                 )}
 

--- a/backend/src/app/search-indexes/_components/DocumentManager/DocumentManagerPanel.tsx
+++ b/backend/src/app/search-indexes/_components/DocumentManager/DocumentManagerPanel.tsx
@@ -54,6 +54,7 @@ import {
     Sparkles,
 } from 'lucide-react';
 import { toast } from 'sonner';
+import { safeUrl, safeMailto } from '@/shared/utils/safe-url';
 import {
     useBrowseDocuments,
     useDocument,
@@ -169,7 +170,12 @@ function summariseArray(values: unknown[]): string {
 function ThumbnailCell({ url }: { url: string }) {
     const [failed, setFailed] = useState(false);
 
-    if (failed) {
+    // A document controls this URL, and an <img src> fetches from whatever host it
+    // names as soon as the row renders — before any click. Anything that is not a
+    // web URL degrades to the same text fallback a broken image already uses.
+    const src = safeUrl(url);
+
+    if (failed || !src) {
         return <span className="text-xs text-muted-foreground" title={url}>{url}</span>;
     }
 
@@ -178,7 +184,7 @@ function ThumbnailCell({ url }: { url: string }) {
         // remote hosts and next.config declares no images.remotePatterns.
         // eslint-disable-next-line @next/next/no-img-element
         <img
-            src={url}
+            src={src}
             alt=""
             title={url}
             className="h-8 w-8 rounded border object-cover"
@@ -232,14 +238,34 @@ function DocumentCell({
         case 'image_url':
             return <ThumbnailCell url={String(value)} />;
 
-        case 'url':
-        case 'email': {
-            const href = type === 'email' ? `mailto:${String(value)}` : String(value);
+        // url and email validate differently, so they no longer share a branch.
+        case 'url': {
+            const href = safeUrl(String(value));
+            if (!href) {
+                return <span title={String(value)}>{String(value)}</span>;
+            }
             return (
                 <a
                     href={href}
-                    target={type === 'url' ? '_blank' : undefined}
-                    rel={type === 'url' ? 'noreferrer' : undefined}
+                    target="_blank"
+                    rel="noreferrer"
+                    onClick={stopRowToggle}
+                    className="text-primary underline-offset-2 hover:underline"
+                    title={String(value)}
+                >
+                    {String(value)}
+                </a>
+            );
+        }
+
+        case 'email': {
+            const href = safeMailto(String(value));
+            if (!href) {
+                return <span title={String(value)}>{String(value)}</span>;
+            }
+            return (
+                <a
+                    href={href}
                     onClick={stopRowToggle}
                     className="text-primary underline-offset-2 hover:underline"
                     title={String(value)}

--- a/backend/src/app/search-indexes/_components/IngestionKeysCard.tsx
+++ b/backend/src/app/search-indexes/_components/IngestionKeysCard.tsx
@@ -10,6 +10,14 @@
  * ships in the embed snippet and is readable from any page running the widget —
  * so it can only ever read. An ingestion key is a secret that can write and
  * delete, which is why it is shown once and never again.
+ *
+ * Every Button here sets type="button" explicitly, and must keep doing so. The
+ * card renders inside the edit page's <form>, and the shared Button spreads its
+ * props onto a bare <button> without defaulting `type` — so an unmarked button
+ * is type="submit" and submits that form. The cost is not cosmetic: submitting
+ * navigates away, and on the create button that means the key is written to the
+ * database and the reveal panel never renders. Only its hash is stored, so the
+ * key is then unrecoverable.
  */
 
 'use client';
@@ -111,7 +119,7 @@ function KeyReveal({
                 <code className="flex-1 overflow-x-auto rounded border border-amber-300 bg-background px-3 py-2 font-mono text-xs">
                     {plaintextKey}
                 </code>
-                <Button variant="outline" size="sm" onClick={handleCopy}>
+                <Button type="button" variant="outline" size="sm" onClick={handleCopy}>
                     {copied ? (
                         <Check className="mr-2 h-3.5 w-3.5" />
                     ) : (
@@ -128,7 +136,7 @@ function KeyReveal({
                         Authorization: Bearer &lt;key&gt;
                     </code>
                 </p>
-                <Button variant="ghost" size="sm" onClick={onDismiss}>
+                <Button type="button" variant="ghost" size="sm" onClick={onDismiss}>
                     I&apos;ve saved it
                 </Button>
             </div>
@@ -225,7 +233,7 @@ function CreateKeyForm({
             </div>
 
             <div className="flex items-center gap-2">
-                <Button onClick={handleSubmit} disabled={createKey.isPending}>
+                <Button type="button" onClick={handleSubmit} disabled={createKey.isPending}>
                     {createKey.isPending ? (
                         <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                     ) : (
@@ -233,7 +241,7 @@ function CreateKeyForm({
                     )}
                     Create key
                 </Button>
-                <Button variant="ghost" onClick={onCancel} disabled={createKey.isPending}>
+                <Button type="button" variant="ghost" onClick={onCancel} disabled={createKey.isPending}>
                     Cancel
                 </Button>
             </div>
@@ -365,6 +373,7 @@ export function IngestionKeysCard({ searchIndexId }: IngestionKeysCardProps) {
                                         <TableCell>
                                             {key.isActive && (
                                                 <Button
+                                                    type="button"
                                                     variant="ghost"
                                                     size="sm"
                                                     className="h-7 w-7 p-0 text-muted-foreground hover:text-red-600"
@@ -395,7 +404,7 @@ export function IngestionKeysCard({ searchIndexId }: IngestionKeysCardProps) {
                 )}
 
                 {!showForm && (
-                    <Button variant="outline" className="w-full rounded-xl" onClick={() => setShowForm(true)}>
+                    <Button type="button" variant="outline" className="w-full rounded-xl" onClick={() => setShowForm(true)}>
                         <Plus className="mr-2 h-4 w-4" />
                         Create ingestion key
                     </Button>

--- a/backend/src/app/search-indexes/_lib/api-client.ts
+++ b/backend/src/app/search-indexes/_lib/api-client.ts
@@ -26,6 +26,7 @@ import type {
     BulkUpdateFieldMappingsDTO,
     FieldMappingConfig,
 } from '@/features/search-index';
+import type { FieldType } from '@/shared/constants/field-types';
 
 // ============================================================================
 // EXPORT/IMPORT TYPES
@@ -900,6 +901,11 @@ export interface DocumentSummary {
 export interface DocumentColumnDescriptor {
     field: string;
     label: string;
+    /**
+     * The field's declared type, used to pick a cell renderer. `'id'` is the
+     * document key column, which has no field definition behind it.
+     */
+    type: FieldType | 'id';
 }
 
 export interface ListDocumentsResponse {

--- a/backend/src/app/search-indexes/_lib/api-client.ts
+++ b/backend/src/app/search-indexes/_lib/api-client.ts
@@ -844,9 +844,29 @@ export interface BatchListItem {
 // INCREMENTAL DOCUMENT UPDATES
 // ============================================================================
 
+/** One vector-source field's contribution to the embedding text. */
+export interface EmbeddingTextPart {
+    fieldName: string;
+    label: string;
+    /** The rendered `Label: value` line, or '' when excluded. */
+    text: string;
+    included: boolean;
+    /** Present only when `included` is false. */
+    excludedBecause?: 'missing' | 'empty' | 'unsupported-type';
+}
+
+/** The text a document's vector was built from, with a per-field breakdown. */
+export interface EmbeddingPreview {
+    text: string;
+    totalChars: number;
+    parts: EmbeddingTextPart[];
+}
+
 export interface GetDocumentResponse {
     documentId: string;
     document: Record<string, unknown>;
+    /** Absent when the index does not embed. */
+    embeddingPreview?: EmbeddingPreview;
 }
 
 /** One operation in a bulk incremental write. */

--- a/backend/src/content/docs/guides/bulk-load-data.md
+++ b/backend/src/content/docs/guides/bulk-load-data.md
@@ -163,12 +163,23 @@ curl "/api/search-indexes/$INDEX/documents?page=1&pageSize=25"
   "success": true,
   "data": {
     "documents": [
-      { "id": "PROD-001", "fields": { "name": "Pacific runner sneaker", "price": 89.99 } }
+      {
+        "id": "PROD-001",
+        "fields": {
+          "name": "Pacific runner sneaker",
+          "category": "footwear",
+          "price": 89.99,
+          "updatedAt": "2025-03-04T09:12:44Z"
+        }
+      }
     ],
-    // A compact set of columns picked from your field config, ID first
+    // A compact set of columns derived from your field config, ID first
     "columns": [
-      { "field": "uniqueId", "label": "ID" },
-      { "field": "name", "label": "Name" }
+      { "field": "uniqueId", "label": "ID", "type": "id" },
+      { "field": "name", "label": "Name", "type": "text" },
+      { "field": "category", "label": "Category", "type": "keyword" },
+      { "field": "price", "label": "Price", "type": "number" },
+      { "field": "updatedAt", "label": "Updated", "type": "datetime" }
     ],
     "pagination": { "page": 1, "pageSize": 25, "totalPages": 17, "totalItems": 412 }
   }
@@ -177,12 +188,23 @@ curl "/api/search-indexes/$INDEX/documents?page=1&pageSize=25"
 
 `pageSize` defaults to 25 and caps at 100. Each document's `id` is the value you pass to the single-document routes above.
 
-Two things to know:
+**Which columns you get.** Indexes have nothing in common but the document key, so the column set isn't fixed — it's derived from your own field configuration, and it follows the same rules on every index:
+
+1. **The key comes first**, always, even on an index that doesn't map a `uniqueId` field.
+2. **Then a title**, if one can be identified — a field named `title`, `name` or `product_name`, otherwise the first searchable text field.
+3. **Then up to three attributes**, ranked by how well they fit in a table cell. Types that render as a single value (`keyword`, `boolean`, `number`, `date`, `datetime`, `url`) rank above prose and structures (`text`, `array`, `json`), and facetable fields rank above non-facetable ones of the same type — a field worth faceting has few distinct values, which is what makes a column scannable.
+4. **Then `updatedAt`** (or `createdAt`), if your index defines them.
+
+Fields marked as a vector source never appear: they hold the long prose that was embedded. Nothing here is configurable — change which fields are searchable, facetable or included in responses, and the columns follow.
+
+Each column carries its `type`, so a client can render the cell as what it is — a thumbnail for `image_url`, a link for `url`, a formatted date for `datetime` — rather than printing a raw value.
+
+Two more things to know:
 
 - **Paging is capped at 10,000 documents.** Past that you get a `400` — Elasticsearch refuses deep pagination and Azure has its own ceiling. To extract an entire large index, use a full export rather than walking pages.
 - **Ordering.** On Elasticsearch documents come back sorted by `uniqueId`, so paging is repeatable. On Azure AI Search the key field is not sortable, so order is provider-defined and rows can in principle shift between pages.
 
-Only a few fields come back per document, not the whole thing — enough to fill a table. Fetch a single document by id for everything. Embedding vectors are never returned by any of these reads; a vector is thousands of floats and useless to look at.
+Only these columns come back per document, not the whole thing — enough to fill a table. Fetch a single document by id for everything. Embedding vectors are never returned by any of these reads; a vector is thousands of floats and useless to look at.
 
 ### Replace vs. partial update
 

--- a/backend/src/features/data-source/data-source.service.ts
+++ b/backend/src/features/data-source/data-source.service.ts
@@ -11,6 +11,7 @@ import type { ExternalSearchIndexConfig, DataSourceField, DataSourceSchema, Data
 import type { SearchIndexField } from '@/db/schema/search-index-fields.schema';
 import { resolveSecret } from '@/features/secrets/secrets.service';
 import { inferFieldRole } from '@/shared/utils/field-roles';
+import * as toolsService from '@/features/tools/tools.service';
 
 const logger = createLogger('data-source-service');
 
@@ -180,13 +181,30 @@ export async function refreshSchemaForSearchIndex(searchIndexId: string): Promis
 
     await Promise.all(
       sources.map(source =>
-        performHealthCheck(source.id).catch(err => {
-          logger.warn('Failed to refresh data source schema', {
-            dataSourceId: source.id,
-            searchIndexId,
-            error: err instanceof Error ? err.message : 'Unknown error',
-          });
-        })
+        performHealthCheck(source.id)
+          .then(async () => {
+            // The data source snapshot is only half of it. A tool's inputSchema —
+            // including the filters[].field enum, the only list of filterable
+            // fields the model ever sees — is generated at scaffold time and never
+            // again. Without this, making a field filterable has no visible
+            // effect: the model still cannot name it in a filter.
+            const refreshed = await repository.getDataSourceById(source.id);
+            if (refreshed) {
+              await toolsService.regenerateSchemasForDataSource(
+                refreshed.id,
+                refreshed.name,
+                refreshed.type,
+                refreshed.schema as DataSourceSchema | null,
+              );
+            }
+          })
+          .catch(err => {
+            logger.warn('Failed to refresh data source schema', {
+              dataSourceId: source.id,
+              searchIndexId,
+              error: err instanceof Error ? err.message : 'Unknown error',
+            });
+          })
       )
     );
   } catch (err) {

--- a/backend/src/features/data-source/data-source.service.ts
+++ b/backend/src/features/data-source/data-source.service.ts
@@ -10,6 +10,7 @@ import type {
 import type { ExternalSearchIndexConfig, DataSourceField, DataSourceSchema, DataSourceCapabilities } from '@/db/schema/data-sources.schema';
 import type { SearchIndexField } from '@/db/schema/search-index-fields.schema';
 import { resolveSecret } from '@/features/secrets/secrets.service';
+import { inferFieldRole } from '@/shared/utils/field-roles';
 
 const logger = createLogger('data-source-service');
 
@@ -239,20 +240,6 @@ function mapSearchIndexFieldsToSchema(fields: SearchIndexField[]): DataSourceFie
       isFacetable: f.isFacetable,
       isFilterable: f.isFacetable, // facetable fields are also filterable
     }));
-}
-
-function inferFieldRole(fieldName: string): DataSourceField['role'] {
-  const name = fieldName.toLowerCase();
-  if (name === 'title' || name === 'name' || name === 'product_name') return 'title';
-  if (name === 'description' || name === 'summary') return 'description';
-  if (name === 'content' || name === 'body' || name === 'text') return 'content';
-  if (name === 'price' || name === 'cost') return 'price';
-  if (name === 'image' || name === 'image_url' || name === 'thumbnail') return 'image';
-  if (name === 'category' || name === 'categories') return 'category';
-  if (name === 'url' || name === 'link' || name === 'href') return 'url';
-  if (name === 'id' || name === 'unique_id') return 'id';
-  if (name.includes('date') || name.includes('created') || name.includes('updated')) return 'date';
-  return null;
 }
 
 // ============================================================================

--- a/backend/src/features/document-indexing/document-columns.test.ts
+++ b/backend/src/features/document-indexing/document-columns.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from 'vitest';
 
 import {
+    isFieldSelectionError,
     resolveDisplayColumns,
+    sameColumns,
     scoreColumnCandidate,
     toProviderFields,
     MAX_ATTRIBUTE_COLUMNS,
@@ -404,5 +406,66 @@ describe('toProviderFields', () => {
         const columns = resolveDisplayColumns(fields);
 
         expect(toProviderFields(columns, fields)).toContain('uniqueId');
+    });
+});
+
+// ============================================================================
+// RETRY GUARDS
+// ============================================================================
+
+describe('sameColumns', () => {
+    it('is true when dropping timestamps changes nothing', () => {
+        // The identical-retry case: an index with no createdAt/updatedAt produces
+        // the same selection either way, so retrying would repeat a failed call.
+        const fields = [keyField(), field({ fieldName: 'status', isFacetable: true })];
+
+        expect(sameColumns(
+            resolveDisplayColumns(fields, { includeTimestamps: true }),
+            resolveDisplayColumns(fields, { includeTimestamps: false }),
+        )).toBe(true);
+    });
+
+    it('is false when a timestamp column is actually present', () => {
+        const fields = [
+            keyField(),
+            field({ fieldName: 'status', isFacetable: true }),
+            timestampField('updatedAt'),
+        ];
+
+        expect(sameColumns(
+            resolveDisplayColumns(fields, { includeTimestamps: true }),
+            resolveDisplayColumns(fields, { includeTimestamps: false }),
+        )).toBe(false);
+    });
+
+    it('compares field order, not just membership', () => {
+        const a = [{ field: 'x', label: 'X', type: 'keyword' as const }];
+        const b = [{ field: 'y', label: 'Y', type: 'keyword' as const }];
+
+        expect(sameColumns(a, a)).toBe(true);
+        expect(sameColumns(a, b)).toBe(false);
+    });
+});
+
+describe('isFieldSelectionError', () => {
+    it('recognises a rejected field selection', () => {
+        expect(isFieldSelectionError('Unknown field \'updatedAt\' in $select')).toBe(true);
+        expect(isFieldSelectionError('no field named updatedAt')).toBe(true);
+        expect(isFieldSelectionError("Could not find field 'createdAt'")).toBe(true);
+        expect(isFieldSelectionError('Field cannot be selected')).toBe(true);
+    });
+
+    it('does NOT match unrelated failures', () => {
+        // The regression this guards: retrying on any failure replaced the real
+        // error with the retry's, so the actual cause never reached the caller.
+        expect(isFieldSelectionError('Unauthorized')).toBe(false);
+        expect(isFieldSelectionError('connect ECONNREFUSED 127.0.0.1:9200')).toBe(false);
+        expect(isFieldSelectionError('index_not_found_exception')).toBe(false);
+        expect(isFieldSelectionError('Request timed out')).toBe(false);
+    });
+
+    it('treats a missing message as not retryable', () => {
+        expect(isFieldSelectionError(undefined)).toBe(false);
+        expect(isFieldSelectionError('')).toBe(false);
     });
 });

--- a/backend/src/features/document-indexing/document-columns.test.ts
+++ b/backend/src/features/document-indexing/document-columns.test.ts
@@ -1,0 +1,408 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+    resolveDisplayColumns,
+    scoreColumnCandidate,
+    toProviderFields,
+    MAX_ATTRIBUTE_COLUMNS,
+} from './document-columns';
+
+import type { SearchIndexField } from '@/db/schema/search-index-fields.schema';
+import type { FieldMappingConfig } from '@/shared/constants/search-index.constants';
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+/**
+ * Build a minimal field. Only the columns the selection reads are meaningful;
+ * the rest is cast away rather than filled with noise.
+ *
+ * Defaults describe an ordinary retrievable field, because the interesting cases
+ * are the ones that deviate.
+ */
+function field(overrides: {
+    fieldName: string;
+    fieldType?: string;
+    displayName?: string | null;
+    isSystemField?: boolean;
+    isSearchable?: boolean;
+    isFacetable?: boolean;
+    isIndexed?: boolean;
+    includeInResponse?: boolean;
+    isMapped?: boolean;
+    isVectorSource?: boolean;
+    transformConfig?: FieldMappingConfig | null;
+}): SearchIndexField {
+    return {
+        fieldName: overrides.fieldName,
+        fieldType: overrides.fieldType ?? 'keyword',
+        displayName: overrides.displayName ?? null,
+        isSystemField: overrides.isSystemField ?? false,
+        isSearchable: overrides.isSearchable ?? false,
+        isFacetable: overrides.isFacetable ?? false,
+        isIndexed: overrides.isIndexed ?? true,
+        includeInResponse: overrides.includeInResponse ?? true,
+        isMapped: overrides.isMapped ?? true,
+        isVectorSource: overrides.isVectorSource ?? false,
+        transformConfig: overrides.transformConfig ?? null,
+    } as unknown as SearchIndexField;
+}
+
+/** The uniqueId system field every index gets at creation. */
+function keyField(displayName: string | null = 'Unique ID'): SearchIndexField {
+    return field({
+        fieldName: 'uniqueId',
+        fieldType: 'keyword',
+        displayName,
+        isSystemField: true,
+        isIndexed: true,
+        transformConfig: { mode: 'default', transform: 'none', generator: 'uuid' } as FieldMappingConfig,
+    });
+}
+
+/**
+ * A timestamp system field (createdAt / updatedAt).
+ *
+ * `mode` is a parameter because real indexes disagree: some carry the generated
+ * mode, others carry mode 'source' with a timestamp generator. Both have to end
+ * up as the pinned last column.
+ */
+function timestampField(
+    fieldName: 'createdAt' | 'updatedAt',
+    mode: 'generated' | 'source' = 'generated'
+): SearchIndexField {
+    return field({
+        fieldName,
+        fieldType: 'datetime',
+        displayName: fieldName === 'updatedAt' ? 'Updated' : 'Created',
+        isSystemField: true,
+        isFacetable: true,
+        isMapped: mode === 'source',
+        transformConfig: { mode, generator: 'timestamp', transform: 'none' } as FieldMappingConfig,
+    });
+}
+
+const names = (columns: { field: string }[]) => columns.map(c => c.field);
+
+// ============================================================================
+// KEY COLUMN
+// ============================================================================
+
+describe('resolveDisplayColumns — key column', () => {
+    it('always puts the document key first', () => {
+        const columns = resolveDisplayColumns([
+            field({ fieldName: 'status' }),
+            keyField(),
+            field({ fieldName: 'title', fieldType: 'text', isSearchable: true }),
+        ]);
+
+        expect(columns[0]).toEqual({ field: 'uniqueId', label: 'Unique ID', type: 'id' });
+    });
+
+    it('synthesises a key column when the index has no uniqueId field', () => {
+        // The provider returns a document key regardless of whether the index
+        // maps one, and without it a row has nothing to act on.
+        const columns = resolveDisplayColumns([field({ fieldName: 'status' })]);
+
+        expect(columns[0]).toEqual({ field: 'uniqueId', label: 'ID', type: 'id' });
+    });
+
+    it('falls back to "ID" when the key field has no display name', () => {
+        const columns = resolveDisplayColumns([keyField(null)]);
+
+        expect(columns[0].label).toBe('ID');
+    });
+
+    it('never repeats the key as an attribute column', () => {
+        const columns = resolveDisplayColumns([keyField(), field({ fieldName: 'status' })]);
+
+        expect(names(columns).filter(name => name === 'uniqueId')).toHaveLength(1);
+    });
+});
+
+// ============================================================================
+// TITLE COLUMN
+// ============================================================================
+
+describe('resolveDisplayColumns — title column', () => {
+    it('pins a title field directly after the key', () => {
+        const columns = resolveDisplayColumns([
+            keyField(),
+            field({ fieldName: 'status', isFacetable: true }),
+            field({ fieldName: 'price', fieldType: 'number' }),
+            field({ fieldName: 'title', fieldType: 'text', displayName: 'Title', isSearchable: true }),
+        ]);
+
+        expect(names(columns)[1]).toBe('title');
+    });
+
+    it('recognises name and product_name as titles', () => {
+        for (const titleName of ['name', 'product_name']) {
+            const columns = resolveDisplayColumns([
+                keyField(),
+                field({ fieldName: 'status', isFacetable: true }),
+                field({ fieldName: titleName, fieldType: 'text' }),
+            ]);
+
+            expect(names(columns)[1]).toBe(titleName);
+        }
+    });
+
+    it('falls back to a searchable text field when no title-ish name exists', () => {
+        const columns = resolveDisplayColumns([
+            keyField(),
+            field({ fieldName: 'sku', fieldType: 'keyword', isFacetable: true }),
+            field({ fieldName: 'heading', fieldType: 'text', isSearchable: true }),
+        ]);
+
+        expect(names(columns)[1]).toBe('heading');
+    });
+
+    it('omits the title slot entirely when nothing qualifies', () => {
+        const columns = resolveDisplayColumns([
+            keyField(),
+            field({ fieldName: 'price', fieldType: 'number' }),
+            field({ fieldName: 'inStock', fieldType: 'boolean' }),
+        ]);
+
+        expect(names(columns)).toEqual(['uniqueId', 'price', 'inStock']);
+    });
+});
+
+// ============================================================================
+// RANKING
+// ============================================================================
+
+describe('resolveDisplayColumns — attribute ranking', () => {
+    it('never shows vector-source fields', () => {
+        // These hold the long prose that was embedded.
+        const columns = resolveDisplayColumns([
+            keyField(),
+            field({ fieldName: 'body', fieldType: 'text', isVectorSource: true, isSearchable: true }),
+            field({ fieldName: 'status', isFacetable: true }),
+        ]);
+
+        expect(names(columns)).not.toContain('body');
+    });
+
+    it('never shows the embedding vector', () => {
+        const columns = resolveDisplayColumns([
+            keyField(),
+            field({ fieldName: 'content_embedding', fieldType: 'json' }),
+            field({ fieldName: 'status', isFacetable: true }),
+        ]);
+
+        expect(names(columns)).not.toContain('content_embedding');
+    });
+
+    it('prefers cell-sized types over structures', () => {
+        const columns = resolveDisplayColumns([
+            keyField(),
+            field({ fieldName: 'metadata', fieldType: 'json' }),
+            field({ fieldName: 'tags', fieldType: 'array' }),
+            field({ fieldName: 'inStock', fieldType: 'boolean' }),
+            field({ fieldName: 'status', fieldType: 'keyword' }),
+        ]);
+
+        // keyword (30) and boolean (25) beat array (-20) and json (-40).
+        expect(names(columns).slice(1, 3)).toEqual(['status', 'inStock']);
+        expect(names(columns)).not.toContain('metadata');
+    });
+
+    it('breaks a type tie on facetability', () => {
+        const columns = resolveDisplayColumns([
+            keyField(),
+            field({ fieldName: 'vendorRef', fieldType: 'keyword', isFacetable: false }),
+            field({ fieldName: 'status', fieldType: 'keyword', isFacetable: true }),
+        ]);
+
+        expect(names(columns)[1]).toBe('status');
+    });
+
+    it('deprioritises catch-all system blobs', () => {
+        const columns = resolveDisplayColumns([
+            keyField(),
+            field({
+                fieldName: 'customFields',
+                fieldType: 'json',
+                isSystemField: true,
+                transformConfig: { mode: 'source', transform: 'none' } as FieldMappingConfig,
+            }),
+            field({ fieldName: 'status', isFacetable: true }),
+        ]);
+
+        expect(names(columns)[1]).toBe('status');
+    });
+
+    it('caps attribute columns regardless of index width', () => {
+        const wide = [
+            keyField(),
+            field({ fieldName: 'title', fieldType: 'text', isSearchable: true }),
+            ...Array.from({ length: 40 }, (_, i) =>
+                field({ fieldName: `attr${i}`, fieldType: 'keyword', isFacetable: true })
+            ),
+        ];
+
+        const columns = resolveDisplayColumns(wide, { includeTimestamps: true });
+
+        // key + title + attributes (no timestamps defined on this index)
+        expect(columns).toHaveLength(2 + MAX_ATTRIBUTE_COLUMNS);
+    });
+
+    it('is stable across repeated calls', () => {
+        const fields = [
+            keyField(),
+            field({ fieldName: 'title', fieldType: 'text', isSearchable: true }),
+            field({ fieldName: 'brand', fieldType: 'keyword', isFacetable: true }),
+            field({ fieldName: 'colour', fieldType: 'keyword', isFacetable: true }),
+            field({ fieldName: 'size', fieldType: 'keyword', isFacetable: true }),
+            field({ fieldName: 'weight', fieldType: 'keyword', isFacetable: true }),
+        ];
+
+        // Equal scores must resolve by field order, not by sort instability.
+        expect(names(resolveDisplayColumns(fields)))
+            .toEqual(names(resolveDisplayColumns(fields)));
+        expect(names(resolveDisplayColumns(fields)))
+            .toEqual(['uniqueId', 'title', 'brand', 'colour', 'size']);
+    });
+
+    it('excludes fields that are not retrievable', () => {
+        const columns = resolveDisplayColumns([
+            keyField(),
+            field({ fieldName: 'internalNote', includeInResponse: false }),
+            field({ fieldName: 'unindexed', isIndexed: false }),
+            field({ fieldName: 'unmapped', isMapped: false }),
+            field({ fieldName: 'status', isFacetable: true }),
+        ]);
+
+        expect(names(columns)).toEqual(['uniqueId', 'status']);
+    });
+});
+
+// ============================================================================
+// TIMESTAMPS
+// ============================================================================
+
+describe('resolveDisplayColumns — timestamps', () => {
+    const withTimestamps = [
+        keyField(),
+        field({ fieldName: 'title', fieldType: 'text', isSearchable: true }),
+        field({ fieldName: 'status', isFacetable: true }),
+        timestampField('createdAt'),
+        timestampField('updatedAt'),
+    ];
+
+    it('pins updatedAt as the last column', () => {
+        const columns = resolveDisplayColumns(withTimestamps, { includeTimestamps: true });
+
+        expect(columns.at(-1)).toEqual({
+            field: 'updatedAt',
+            label: 'Updated',
+            type: 'datetime',
+        });
+    });
+
+    it('prefers updatedAt over createdAt, showing only one', () => {
+        const columns = resolveDisplayColumns(withTimestamps, { includeTimestamps: true });
+
+        expect(names(columns)).not.toContain('createdAt');
+    });
+
+    it('falls back to createdAt when updatedAt is absent', () => {
+        const columns = resolveDisplayColumns(
+            [keyField(), field({ fieldName: 'status' }), timestampField('createdAt')],
+            { includeTimestamps: true }
+        );
+
+        expect(columns.at(-1)?.field).toBe('createdAt');
+    });
+
+    it('omits generated-mode timestamps by default', () => {
+        // The default is the safe one: a field row in Postgres is no proof the
+        // provider mapping has the field.
+        const columns = resolveDisplayColumns(withTimestamps);
+
+        expect(names(columns)).not.toContain('updatedAt');
+        expect(names(columns)).not.toContain('createdAt');
+    });
+
+    it('pins source-mode timestamps last too', () => {
+        // Real indexes configure these as mode 'source' with a timestamp
+        // generator as often as mode 'generated'. Detection is by field name for
+        // exactly this reason — a source-mode updatedAt is already retrievable,
+        // so it must not end up competing for an attribute slot.
+        const sourceMode = [
+            keyField(),
+            field({ fieldName: 'title', fieldType: 'text', isSearchable: true }),
+            field({ fieldName: 'category', isFacetable: true }),
+            field({ fieldName: 'brand', isFacetable: true }),
+            field({ fieldName: 'season', isFacetable: true }),
+            field({ fieldName: 'style', isFacetable: true }),
+            timestampField('createdAt', 'source'),
+            timestampField('updatedAt', 'source'),
+        ];
+
+        // Not passed includeTimestamps: source mode is retrievable on its own.
+        const columns = resolveDisplayColumns(sourceMode);
+
+        expect(columns.at(-1)?.field).toBe('updatedAt');
+        expect(names(columns)).toEqual([
+            'uniqueId', 'title', 'category', 'brand', 'season', 'updatedAt',
+        ]);
+    });
+
+    it('never spends an attribute slot on a timestamp', () => {
+        const columns = resolveDisplayColumns(withTimestamps, { includeTimestamps: true });
+
+        expect(names(columns)).toEqual(['uniqueId', 'title', 'status', 'updatedAt']);
+    });
+});
+
+// ============================================================================
+// SCORING + PROVIDER FIELDS
+// ============================================================================
+
+describe('scoreColumnCandidate', () => {
+    it('scores a faceted keyword above analyzed prose', () => {
+        const keyword = scoreColumnCandidate(field({ fieldName: 'status', isFacetable: true }));
+        const prose = scoreColumnCandidate(field({ fieldName: 'summary', fieldType: 'text' }));
+
+        expect(keyword).toBeGreaterThan(prose);
+    });
+
+    it('scores structures below everything else', () => {
+        const json = scoreColumnCandidate(field({ fieldName: 'meta', fieldType: 'json' }));
+        const array = scoreColumnCandidate(field({ fieldName: 'tags', fieldType: 'array' }));
+
+        expect(json).toBeLessThan(array);
+        expect(array).toBeLessThan(
+            scoreColumnCandidate(field({ fieldName: 'label', fieldType: 'text' }))
+        );
+    });
+
+    it('rewards recognised roles', () => {
+        const priced = scoreColumnCandidate(field({ fieldName: 'price', fieldType: 'number' }));
+        const plain = scoreColumnCandidate(field({ fieldName: 'weight', fieldType: 'number' }));
+
+        expect(priced).toBeGreaterThan(plain);
+    });
+});
+
+describe('toProviderFields', () => {
+    it('drops a synthetic key column the index does not define', () => {
+        // Azure's `select` throws on an unknown field, so the provider list has to
+        // be narrower than the column list.
+        const fields = [field({ fieldName: 'status' })];
+        const columns = resolveDisplayColumns(fields);
+
+        expect(toProviderFields(columns, fields)).toEqual(['status']);
+    });
+
+    it('keeps the key when the index defines it', () => {
+        const fields = [keyField(), field({ fieldName: 'status' })];
+        const columns = resolveDisplayColumns(fields);
+
+        expect(toProviderFields(columns, fields)).toContain('uniqueId');
+    });
+});

--- a/backend/src/features/document-indexing/document-columns.ts
+++ b/backend/src/features/document-indexing/document-columns.ts
@@ -250,6 +250,56 @@ export function resolveDisplayColumns(
     return columns;
 }
 
+// ============================================================================
+// RETRY
+// ============================================================================
+
+/**
+ * Whether two column sets are the same selection.
+ *
+ * Guards the fallback retry: on an index with no createdAt/updatedAt, dropping the
+ * optional columns produces an identical list, so retrying is a guaranteed-identical
+ * second round trip against a provider that just failed.
+ */
+export function sameColumns(a: DocumentColumn[], b: DocumentColumn[]): boolean {
+    if (a.length !== b.length) {
+        return false;
+    }
+    return a.every((column, index) => column.field === b[index].field);
+}
+
+/**
+ * Substrings that indicate a provider rejected the *field selection*, rather than
+ * failing for some unrelated reason. Azure throws on selecting a field its index
+ * does not define; Elasticsearch phrases the same class of problem differently.
+ */
+const FIELD_SELECTION_ERROR_PATTERNS = [
+    'unknown field',
+    'no field named',
+    'cannot be selected',
+    'could not find field',
+    'invalid field',
+    'no such field',
+    'unknown key',
+];
+
+/**
+ * Whether a provider error looks like a rejected field selection.
+ *
+ * Providers return a bare string — `{ success: false, error: message }` with no
+ * code — so this cannot be exact. It errs towards NOT retrying: an unrecognised
+ * message means the original error propagates untouched, which is the point. The
+ * previous condition retried on any failure at all, so an auth or network error
+ * was replaced by the retry's error and the real cause survived only in a log line.
+ */
+export function isFieldSelectionError(message: string | undefined): boolean {
+    if (!message) {
+        return false;
+    }
+    const normalized = message.toLowerCase();
+    return FIELD_SELECTION_ERROR_PATTERNS.some(pattern => normalized.includes(pattern));
+}
+
 /**
  * Narrow display columns to field names the index actually has.
  *

--- a/backend/src/features/document-indexing/document-columns.ts
+++ b/backend/src/features/document-indexing/document-columns.ts
@@ -1,0 +1,266 @@
+// src/features/document-indexing/document-columns.ts
+
+/**
+ * Document Display Columns
+ *
+ * Chooses a compact set of columns for summarising a document in a table.
+ *
+ * Indexes have wildly different schemas — the only field every index shares is
+ * the document key — so there is no fixed column set that works everywhere. What
+ * every index does have is field metadata: a declared type, whether the field is
+ * facetable, searchable, a vector source. That is enough to derive good columns
+ * without asking anyone to configure anything.
+ *
+ * Kept free of db/provider imports so it can be tested directly, the same way
+ * field-dependents.ts is.
+ */
+
+import type { SearchIndexField } from '@/db/schema/search-index-fields.schema';
+import { buildBrowsableFields } from '@/features/search/search-context.builder';
+import type { FieldType } from '@/shared/constants/field-types';
+import { inferFieldRole } from '@/shared/utils/field-roles';
+
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+
+/**
+ * Attribute columns between the title and the timestamp.
+ *
+ * The full budget is key + title + attributes + timestamp = 6 columns, which is
+ * about as wide as the table stays readable at.
+ */
+export const MAX_ATTRIBUTE_COLUMNS = 3;
+
+/** Field the document key is mapped from. */
+export const DOCUMENT_KEY_FIELD = 'uniqueId';
+
+/**
+ * Reserved timestamp field names, in the order they are preferred for the last
+ * column. Only one is ever shown.
+ */
+const TIMESTAMP_FIELD_PREFERENCE = ['updatedAt', 'createdAt'] as const;
+
+/**
+ * Whether a field is the index's last-changed / first-seen timestamp.
+ *
+ * Matched by name, not by mapping mode. `createdAt`/`updatedAt` are reserved
+ * system field names, but how they are configured varies across real indexes —
+ * some carry mode 'generated', others mode 'source' with a timestamp generator —
+ * and either way the column belongs pinned at the end rather than competing for
+ * an attribute slot.
+ */
+function isTimestampColumn(field: SearchIndexField): boolean {
+    return (TIMESTAMP_FIELD_PREFERENCE as readonly string[]).includes(field.fieldName);
+}
+
+/**
+ * The dense vector field. Duplicated from document-indexer.service rather than
+ * imported, because that module pulls in the db and the AI service and this one
+ * is deliberately dependency-free.
+ */
+const EMBEDDING_FIELD = 'content_embedding';
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+export interface DocumentColumn {
+    field: string;
+    label: string;
+    /**
+     * Declared field type, so a client can render the cell according to what it
+     * holds rather than stringifying everything. The key column reports 'id':
+     * it is the provider's document key, which has no field row of its own when
+     * the index does not define uniqueId.
+     */
+    type: FieldType | 'id';
+}
+
+// ============================================================================
+// SELECTION
+// ============================================================================
+
+/**
+ * Score a field on how well it works as a table column.
+ *
+ * The question is not "is this field important?" but "does this field fit in a
+ * cell?" — a keyword status renders as one glanceable token, a JSON blob renders
+ * as unreadable noise no matter how important it is. Facetability is a strong
+ * signal here for free: a field worth faceting is a field with few distinct
+ * values, which is exactly what makes a column scannable.
+ *
+ * Roles come from the field name (see inferFieldRole) so an index with no display
+ * configuration at all still gets sensible picks.
+ */
+export function scoreColumnCandidate(field: SearchIndexField): number {
+    let score = 0;
+
+    switch (field.fieldType as FieldType) {
+        case 'keyword':
+            score += 30;
+            break;
+        case 'boolean':
+        case 'number':
+        case 'date':
+        case 'datetime':
+            score += 25;
+            break;
+        case 'url':
+        case 'email':
+            score += 20;
+            break;
+        case 'image_url':
+            score += 5;
+            break;
+        case 'text':
+            // Analyzed prose: could be a short heading, could be three
+            // paragraphs. Not worth a column unless nothing better exists.
+            score -= 10;
+            break;
+        case 'array':
+            score -= 20;
+            break;
+        case 'json':
+            score -= 40;
+            break;
+    }
+
+    if (field.isFacetable) {
+        score += 15;
+    }
+
+    // additionalData / customFields are catch-all blobs by design.
+    if (field.isSystemField) {
+        score -= 30;
+    }
+
+    switch (inferFieldRole(field.fieldName)) {
+        case 'category':
+        case 'price':
+            score += 40;
+            break;
+        case 'date':
+        case 'url':
+            score += 20;
+            break;
+    }
+
+    return score;
+}
+
+/**
+ * Pick the field that best identifies a document to a human.
+ *
+ * Prefers an explicit title-ish name, and falls back to the first searchable
+ * short-text field — on an index with no `title` at all, a field someone chose to
+ * make searchable is the closest thing to a label available.
+ */
+function pickTitleField(candidates: SearchIndexField[]): SearchIndexField | undefined {
+    const titled = candidates.find(f => inferFieldRole(f.fieldName) === 'title');
+    if (titled) {
+        return titled;
+    }
+    return candidates.find(f =>
+        f.isSearchable && (f.fieldType === 'text' || f.fieldType === 'keyword')
+    );
+}
+
+/**
+ * Pick a compact set of fields for summarising a document in a table.
+ *
+ * Columns are laid out as identity → detail → recency, so a row reads
+ * left-to-right: which document is this, what is it, when did it last change.
+ *
+ * Candidates come from buildBrowsableFields(), which applies the same
+ * retrievability filter as search (includeInResponse && isIndexed &&
+ * hasDataAvailable && !isEmptySystemField). That filter matters beyond tidiness:
+ * Azure's `select` throws on a field the index does not actually have.
+ *
+ * Vector-source fields are excluded outright — they hold the long prose that was
+ * embedded, which makes a table unreadable regardless of how it scores.
+ *
+ * @param fields - Every field defined for the index
+ * @param options.includeTimestamps - Admit generated createdAt/updatedAt. Off by
+ *   default because a field row in Postgres is no proof the provider mapping has
+ *   the field; the caller decides whether the index is in sync enough to ask.
+ */
+export function resolveDisplayColumns(
+    fields: SearchIndexField[],
+    options: { includeTimestamps?: boolean } = {}
+): DocumentColumn[] {
+    const includeTimestamps = options.includeTimestamps ?? false;
+
+    const toColumn = (field: SearchIndexField): DocumentColumn => ({
+        field: field.fieldName,
+        label: field.displayName || field.fieldName,
+        type: field.fieldType as FieldType,
+    });
+
+    const keyField = fields.find(f => f.fieldName === DOCUMENT_KEY_FIELD);
+
+    // The key column always leads, and is always present even when the index has
+    // no mapped uniqueId field — the provider returns a document key regardless,
+    // and without it a table row has nothing to act on. Callers rely on this
+    // position: columns[0] is the document id.
+    const columns: DocumentColumn[] = [{
+        field: DOCUMENT_KEY_FIELD,
+        label: keyField?.displayName || 'ID',
+        type: 'id',
+    }];
+
+    const browsable = buildBrowsableFields(fields, {
+        includeGeneratedTimestamps: includeTimestamps,
+    });
+
+    const timestampFields = browsable.filter(isTimestampColumn);
+
+    const candidates = browsable.filter(field =>
+        field.fieldName !== DOCUMENT_KEY_FIELD
+        && field.fieldName !== EMBEDDING_FIELD
+        && !field.isVectorSource
+        && !isTimestampColumn(field)
+    );
+
+    const titleField = pickTitleField(candidates);
+    if (titleField) {
+        columns.push(toColumn(titleField));
+    }
+
+    // Sort a copy: `candidates` order is the field definition order, which is the
+    // tiebreak that keeps this selection stable across calls.
+    const ranked = candidates
+        .filter(field => field.fieldName !== titleField?.fieldName)
+        .map((field, position) => ({ field, position, score: scoreColumnCandidate(field) }))
+        .sort((a, b) => b.score - a.score || a.position - b.position);
+
+    for (const { field } of ranked.slice(0, MAX_ATTRIBUTE_COLUMNS)) {
+        columns.push(toColumn(field));
+    }
+
+    // Recency last, so the eye lands on it after the identifying columns.
+    for (const fieldName of TIMESTAMP_FIELD_PREFERENCE) {
+        const timestamp = timestampFields.find(f => f.fieldName === fieldName);
+        if (timestamp) {
+            columns.push(toColumn(timestamp));
+            break;
+        }
+    }
+
+    return columns;
+}
+
+/**
+ * Narrow display columns to field names the index actually has.
+ *
+ * The key column can be synthetic (see resolveDisplayColumns), and Azure's
+ * `select` throws on a field the index does not define — so the list handed to a
+ * provider has to be filtered even though the column list is not.
+ */
+export function toProviderFields(
+    columns: DocumentColumn[],
+    fields: SearchIndexField[]
+): string[] {
+    const known = new Set(fields.map(f => f.fieldName));
+    return columns.map(c => c.field).filter(field => known.has(field));
+}

--- a/backend/src/features/document-indexing/document-indexer.service.ts
+++ b/backend/src/features/document-indexing/document-indexer.service.ts
@@ -30,6 +30,7 @@ import * as fieldsRepository from '@/features/search-index/search-index-fields.r
 import { generateEmbeddings } from '@/features/ai-service';
 import type { SearchIndexField } from '@/db/schema/search-index-fields.schema';
 import { getProviderSettings, getProviderFieldSettings } from '@/features/search-index/provider-settings.utils';
+import { getEmbeddingText } from './embedding-text';
 
 const logger = createLogger('document-indexer');
 
@@ -271,28 +272,12 @@ export function getEmbeddingConfig(index: {
 }
 
 /**
- * Get text content from vector source fields for embedding
+ * Get text content from vector source fields for embedding.
+ *
+ * Re-exported from embedding-text.ts, which owns the construction rules and is
+ * shared with the preview the admin UI renders, so the two can never drift.
  */
-export function getEmbeddingText(
-    document: Record<string, unknown>,
-    vectorSourceFields: SearchIndexField[]
-): string {
-    const textParts: string[] = [];
-
-    for (const field of vectorSourceFields) {
-        const value = document[field.fieldName];
-        if (value !== undefined && value !== null) {
-            if (typeof value === 'string') {
-                textParts.push(value);
-            } else if (Array.isArray(value)) {
-                // Join array values
-                textParts.push(value.filter(v => typeof v === 'string').join(' '));
-            }
-        }
-    }
-
-    return textParts.join('\n\n');
-}
+export { getEmbeddingText };
 
 /**
  * Generate embeddings for documents

--- a/backend/src/features/document-indexing/document-indexer.service.ts
+++ b/backend/src/features/document-indexing/document-indexer.service.ts
@@ -296,8 +296,12 @@ export function getEmbeddingText(
 
 /**
  * Generate embeddings for documents
+ *
+ * Exported because a reindex has to rebuild vectors too: `content_embedding` is
+ * not carried in `_source`, so a rebuild that only copies documents across
+ * produces an index with no vectors at all.
  */
-async function generateDocumentEmbeddings(
+export async function generateDocumentEmbeddings(
     documents: Array<{ _id?: string; [key: string]: unknown }>,
     vectorSourceFields: SearchIndexField[],
     embeddingConfig: EmbeddingConfig,

--- a/backend/src/features/document-indexing/document-indexing.api.handlers.ts
+++ b/backend/src/features/document-indexing/document-indexing.api.handlers.ts
@@ -686,6 +686,7 @@ export async function handleGetDocument(
         const response: GetDocumentResponse = {
             documentId: result.documentId,
             document: result.document,
+            embeddingPreview: result.embeddingPreview,
         };
 
         return apiResponse.success(response);

--- a/backend/src/features/document-indexing/document-indexing.types.ts
+++ b/backend/src/features/document-indexing/document-indexing.types.ts
@@ -7,6 +7,7 @@
 
 import { z } from 'zod';
 import { filterClauseSchema } from '@/features/search/search.validation';
+import type { FieldType } from '@/shared/constants/field-types';
 
 // ============================================================================
 // VALIDATION SCHEMAS
@@ -148,8 +149,9 @@ export type {
     DocumentReadResult,
     DeleteByFilterOutcome,
     ListDocumentsOutcome,
-    DocumentColumn,
 } from './document-writer.service';
+
+export type { DocumentColumn } from './document-columns';
 
 export type {
     IndexingRequest,
@@ -271,6 +273,14 @@ export interface DocumentSummary {
 export interface DocumentColumnDescriptor {
     field: string;
     label: string;
+    /**
+     * The field's declared type, so the cell can be rendered as what it is — a
+     * thumbnail, a link, a formatted date — instead of a stringified value.
+     *
+     * `'id'` marks the document key column, which has no field definition of its
+     * own on an index that does not define uniqueId.
+     */
+    type: FieldType | 'id';
 }
 
 /**

--- a/backend/src/features/document-indexing/document-indexing.types.ts
+++ b/backend/src/features/document-indexing/document-indexing.types.ts
@@ -8,6 +8,7 @@
 import { z } from 'zod';
 import { filterClauseSchema } from '@/features/search/search.validation';
 import type { FieldType } from '@/shared/constants/field-types';
+import type { EmbeddingPreview } from './embedding-text';
 
 // ============================================================================
 // VALIDATION SCHEMAS
@@ -154,6 +155,12 @@ export type {
 export type { DocumentColumn } from './document-columns';
 
 export type {
+    EmbeddingPreview,
+    EmbeddingTextPart,
+    EmbeddingPartExclusion,
+} from './embedding-text';
+
+export type {
     IndexingRequest,
     IndexingProgress,
     IndexingResult,
@@ -225,6 +232,14 @@ export interface IndexDocumentsResponse {
 export interface GetDocumentResponse {
     documentId: string;
     document: Record<string, unknown>;
+    /**
+     * Exactly the text this document's vector was built from, with a per-field
+     * breakdown of what contributed and what did not. Absent when the index does
+     * not embed. The stored vector is stripped from every read and a bad one
+     * looks like a good one, so this is the only way to see why a document does
+     * or does not match semantically.
+     */
+    embeddingPreview?: EmbeddingPreview;
 }
 
 /**

--- a/backend/src/features/document-indexing/document-writer.service.ts
+++ b/backend/src/features/document-indexing/document-writer.service.ts
@@ -39,7 +39,9 @@ import { buildSearchContext } from '@/features/search/search-context.builder';
 import type { FilterClause, SearchContext } from '@/features/search/search.types';
 import {
     DOCUMENT_KEY_FIELD,
+    isFieldSelectionError,
     resolveDisplayColumns,
+    sameColumns,
     toProviderFields,
     type DocumentColumn,
 } from './document-columns';
@@ -341,16 +343,30 @@ export async function listDocuments(
     let result = await fetchPage(columns);
 
     // The requiresReindex flag is the primary guard, but it only catches drift the
-    // platform recorded. If the selection failed anyway, retry once without the
-    // optional columns — browsing without a timestamp column beats not browsing.
-    if (!result.success && includeTimestamps) {
-        logger.warn('Document listing failed with optional columns; retrying without them', {
-            searchIndexId,
-            indexName: index.name,
-            error: result.error,
-        });
-        columns = resolveDisplayColumns(index.fields, { includeTimestamps: false });
-        result = await fetchPage(columns);
+    // platform recorded. If the *field selection* was rejected anyway, retry once
+    // without the optional columns — browsing without a timestamp column beats not
+    // browsing. Any other failure (auth, network, missing index) is left alone so
+    // its error reaches the caller intact.
+    if (!result.success && includeTimestamps && isFieldSelectionError(result.error)) {
+        const fallbackColumns = resolveDisplayColumns(index.fields, { includeTimestamps: false });
+
+        if (!sameColumns(columns, fallbackColumns)) {
+            logger.warn('Document listing failed on field selection; retrying without optional columns', {
+                searchIndexId,
+                indexName: index.name,
+                error: result.error,
+            });
+
+            const retry = await fetchPage(fallbackColumns);
+
+            // Only adopt the retry when it worked. Otherwise `result` still holds the
+            // original failure, so the error thrown below describes the real cause
+            // rather than the retry's.
+            if (retry.success) {
+                columns = fallbackColumns;
+                result = retry;
+            }
+        }
     }
 
     if (!result.success) {
@@ -738,18 +754,29 @@ export async function deleteDocumentsByFilter(
 
     let result = await runDelete(columns);
 
-    // Retry without the optional columns on a failed selection, mirroring
+    // Retry without the optional columns on a rejected field selection, mirroring
     // listDocuments — but only for a dry run. A real delete is never re-run: it
     // may have deleted documents before failing, and sampleFields is not even
     // sent on that path, so the columns cannot be what broke it.
-    if (!result.success && dryRun && includeTimestamps) {
-        logger.warn('Delete-by-filter preview failed with optional columns; retrying without them', {
-            searchIndexId,
-            indexName: index.name,
-            error: result.error,
-        });
-        columns = resolveDisplayColumns(index.fields, { includeTimestamps: false });
-        result = await runDelete(columns);
+    if (!result.success && dryRun && includeTimestamps && isFieldSelectionError(result.error)) {
+        const fallbackColumns = resolveDisplayColumns(index.fields, { includeTimestamps: false });
+
+        if (!sameColumns(columns, fallbackColumns)) {
+            logger.warn('Delete-by-filter preview failed on field selection; retrying without optional columns', {
+                searchIndexId,
+                indexName: index.name,
+                error: result.error,
+            });
+
+            const retry = await runDelete(fallbackColumns);
+
+            // Keep the original failure unless the retry actually succeeded, so the
+            // error thrown below is the one describing the real cause.
+            if (retry.success) {
+                columns = fallbackColumns;
+                result = retry;
+            }
+        }
     }
 
     if (!result.success) {

--- a/backend/src/features/document-indexing/document-writer.service.ts
+++ b/backend/src/features/document-indexing/document-writer.service.ts
@@ -37,6 +37,12 @@ import type {
 } from '@/features/search/providers/search-engine-provider.interface';
 import { buildSearchContext } from '@/features/search/search-context.builder';
 import type { FilterClause, SearchContext } from '@/features/search/search.types';
+import {
+    DOCUMENT_KEY_FIELD,
+    resolveDisplayColumns,
+    toProviderFields,
+    type DocumentColumn,
+} from './document-columns';
 import * as searchIndexService from '@/features/search-index/search-index.service';
 import * as fieldsService from '@/features/search-index/search-index-fields.service';
 import * as fieldsRepository from '@/features/search-index/search-index-fields.repository';
@@ -154,6 +160,12 @@ interface ResolvedIndex {
     providerType: SearchProviderType;
     fields: SearchIndexField[];
     embeddingConfig: EmbeddingConfig;
+    /**
+     * Whether the field definitions have drifted from the provider mapping. When
+     * true, a field row existing in Postgres is no proof the provider knows the
+     * field, so optional columns are not requested.
+     */
+    requiresReindex: boolean;
 }
 
 /**
@@ -194,6 +206,7 @@ async function resolveIndex(searchIndexId: string): Promise<ResolvedIndex> {
         providerType,
         fields,
         embeddingConfig: getEmbeddingConfig(index),
+        requiresReindex: index.requiresReindex ?? false,
     };
 }
 
@@ -216,80 +229,6 @@ async function resolveSearchContextUngated(searchIndexId: string): Promise<Searc
         throw new SearchIndexNotFoundError('Search index not found');
     }
     return buildSearchContext(index);
-}
-
-// ============================================================================
-// DISPLAY COLUMNS
-// ============================================================================
-
-/** Maximum non-key columns in a document summary. */
-const MAX_DISPLAY_COLUMNS = 4;
-
-/** Field the document key is mapped from. */
-const DOCUMENT_KEY_FIELD = 'uniqueId';
-
-export interface DocumentColumn {
-    field: string;
-    label: string;
-}
-
-/**
- * Pick a compact set of fields for summarising a document in a table.
- *
- * Starts from context.defaultResponseFields, which is already filtered for
- * retrievability (includeInResponse && isIndexed && hasDataAvailable &&
- * !isEmptySystemField). That filter matters beyond tidiness: Azure's `select`
- * throws on a field the index does not actually have.
- *
- * The key field always leads so a row can be acted on, and vector-source fields
- * are skipped — they hold long prose that makes a table unreadable.
- */
-function resolveDisplayColumns(
-    index: ResolvedIndex,
-    context: SearchContext
-): DocumentColumn[] {
-    const byName = new Map(index.fields.map(f => [f.fieldName, f]));
-    const label = (fieldName: string) =>
-        byName.get(fieldName)?.displayName || fieldName;
-
-    // The key column always leads, and is always present even when the index has
-    // no mapped uniqueId field — the provider returns a document key regardless,
-    // and without it a table row has nothing to act on. Callers rely on this
-    // position: columns[0] is the document id.
-    const columns: DocumentColumn[] = [{
-        field: DOCUMENT_KEY_FIELD,
-        label: byName.has(DOCUMENT_KEY_FIELD) ? label(DOCUMENT_KEY_FIELD) : 'ID',
-    }];
-
-    for (const fieldName of context.defaultResponseFields) {
-        if (columns.length > MAX_DISPLAY_COLUMNS) {
-            break;
-        }
-        if (fieldName === DOCUMENT_KEY_FIELD || fieldName === EMBEDDING_FIELD_NAME) {
-            continue;
-        }
-        if (byName.get(fieldName)?.isVectorSource) {
-            continue;
-        }
-        columns.push({ field: fieldName, label: label(fieldName) });
-    }
-
-    return columns;
-}
-
-/**
- * Narrow display columns to field names the index actually has.
- *
- * The key column can be synthetic (see resolveDisplayColumns), and Azure's
- * `select` throws on a field the index does not define — so the list handed to a
- * provider has to be filtered even though the column list is not.
- */
-function toProviderFields(
-    columns: DocumentColumn[],
-    index: ResolvedIndex
-): string[] {
-    const known = new Set(index.fields.map(f => f.fieldName));
-    return columns.map(c => c.field).filter(field => known.has(field));
 }
 
 /**
@@ -344,19 +283,39 @@ export async function listDocuments(
     const { page, pageSize } = options;
 
     const index = await resolveIndex(searchIndexId);
-    const context = await resolveSearchContextUngated(searchIndexId);
-    const columns = resolveDisplayColumns(index, context);
 
-    const result = await index.provider.listDocuments(index.name, {
-        offset: (page - 1) * pageSize,
-        limit: pageSize,
-        fields: toProviderFields(columns, index),
-        // Only sort by the key when it is a real field; sorting on a field the
-        // index does not define fails outright.
-        ...(index.fields.some(f => f.fieldName === DOCUMENT_KEY_FIELD)
-            ? { sortField: DOCUMENT_KEY_FIELD }
-            : {}),
-    });
+    // Timestamps are only requested when the field definitions are known to match
+    // the provider mapping. Selecting a field Azure does not have throws, which
+    // would fail the whole page rather than blank one column.
+    const includeTimestamps = !index.requiresReindex;
+    let columns = resolveDisplayColumns(index.fields, { includeTimestamps });
+
+    const fetchPage = (forColumns: DocumentColumn[]) =>
+        index.provider.listDocuments(index.name, {
+            offset: (page - 1) * pageSize,
+            limit: pageSize,
+            fields: toProviderFields(forColumns, index.fields),
+            // Only sort by the key when it is a real field; sorting on a field the
+            // index does not define fails outright.
+            ...(index.fields.some(f => f.fieldName === DOCUMENT_KEY_FIELD)
+                ? { sortField: DOCUMENT_KEY_FIELD }
+                : {}),
+        });
+
+    let result = await fetchPage(columns);
+
+    // The requiresReindex flag is the primary guard, but it only catches drift the
+    // platform recorded. If the selection failed anyway, retry once without the
+    // optional columns — browsing without a timestamp column beats not browsing.
+    if (!result.success && includeTimestamps) {
+        logger.warn('Document listing failed with optional columns; retrying without them', {
+            searchIndexId,
+            indexName: index.name,
+            error: result.error,
+        });
+        columns = resolveDisplayColumns(index.fields, { includeTimestamps: false });
+        result = await fetchPage(columns);
+    }
 
     if (!result.success) {
         throw new Error(result.error || 'Failed to list documents');
@@ -722,19 +681,40 @@ export async function deleteDocumentsByFilter(
     // validation (is this field filterable? what type is it?) matches search.
     const context = await resolveSearchContextUngated(searchIndexId);
     const filterExpression = index.provider.buildFilterExpression(filters, context);
-    const columns = resolveDisplayColumns(index, context);
 
-    const result = await index.provider.deleteByFilter(index.name, filterExpression, {
-        refresh: elasticsearchConfig.indexing.refreshOnComplete,
-        dryRun,
-        // Only a dry run needs a sample; the real delete pays nothing for it.
-        ...(dryRun
-            ? {
-                sampleSize: options?.sampleSize ?? 0,
-                sampleFields: toProviderFields(columns, index),
-            }
-            : {}),
-    });
+    // Same column set as browse, so the preview a user confirms against looks like
+    // the table they were just looking at — including the timestamp guard.
+    const includeTimestamps = !index.requiresReindex;
+    let columns = resolveDisplayColumns(index.fields, { includeTimestamps });
+
+    const runDelete = (forColumns: DocumentColumn[]) =>
+        index.provider.deleteByFilter(index.name, filterExpression, {
+            refresh: elasticsearchConfig.indexing.refreshOnComplete,
+            dryRun,
+            // Only a dry run needs a sample; the real delete pays nothing for it.
+            ...(dryRun
+                ? {
+                    sampleSize: options?.sampleSize ?? 0,
+                    sampleFields: toProviderFields(forColumns, index.fields),
+                }
+                : {}),
+        });
+
+    let result = await runDelete(columns);
+
+    // Retry without the optional columns on a failed selection, mirroring
+    // listDocuments — but only for a dry run. A real delete is never re-run: it
+    // may have deleted documents before failing, and sampleFields is not even
+    // sent on that path, so the columns cannot be what broke it.
+    if (!result.success && dryRun && includeTimestamps) {
+        logger.warn('Delete-by-filter preview failed with optional columns; retrying without them', {
+            searchIndexId,
+            indexName: index.name,
+            error: result.error,
+        });
+        columns = resolveDisplayColumns(index.fields, { includeTimestamps: false });
+        result = await runDelete(columns);
+    }
 
     if (!result.success) {
         throw new Error(result.error || 'Delete by filter failed');

--- a/backend/src/features/document-indexing/document-writer.service.ts
+++ b/backend/src/features/document-indexing/document-writer.service.ts
@@ -322,8 +322,8 @@ export async function listDocuments(
 
     const index = await resolveIndex(searchIndexId);
 
-    // Timestamps are only requested when the field definitions are known to match
-    // the provider mapping. Selecting a field Azure does not have throws, which
+    // Generated timestamps (createdAt/updatedAt) are only requested when the field definitions are
+    // known to match the provider mapping. Selecting a field Azure does not have throws, which
     // would fail the whole page rather than blank one column.
     const includeTimestamps = !index.requiresReindex;
     let columns = resolveDisplayColumns(index.fields, { includeTimestamps });

--- a/backend/src/features/document-indexing/document-writer.service.ts
+++ b/backend/src/features/document-indexing/document-writer.service.ts
@@ -50,9 +50,13 @@ import { generateEmbeddings } from '@/features/ai-service';
 import type { SearchIndexField } from '@/db/schema/search-index-fields.schema';
 import { transformDocument } from './document-transformer.service';
 import {
+    buildEmbeddingPreview,
+    getEmbeddingText,
+    type EmbeddingPreview,
+} from './embedding-text';
+import {
     EMBEDDING_FIELD_NAME,
     getEmbeddingConfig,
-    getEmbeddingText,
     updateIndexStats,
     type EmbeddingConfig,
 } from './document-indexer.service';
@@ -116,6 +120,8 @@ export interface DocumentReadResult {
     found: boolean;
     documentId: string;
     document?: Record<string, unknown>;
+    /** The text this document's vector was built from. Absent on lexical indexes. */
+    embeddingPreview?: EmbeddingPreview;
 }
 
 export interface DeleteByFilterOutcome {
@@ -254,6 +260,11 @@ function withoutEmbedding(source: Record<string, unknown>): Record<string, unkno
 
 /**
  * Fetch a single document from the provider index by id.
+ *
+ * The embedding preview travels with the document because the stored vector is
+ * opaque — it is stripped from every read, and a wrong one looks identical to a
+ * right one. Showing the text it was built from is the only way to see why a
+ * document does or does not match semantically.
  */
 export async function getDocument(
     searchIndexId: string,
@@ -262,11 +273,36 @@ export async function getDocument(
     const index = await resolveIndex(searchIndexId);
     const result = await index.provider.getDocumentById(index.name, documentId);
 
+    const document = result.source ? withoutEmbedding(result.source) : undefined;
+
     return {
         found: result.found,
         documentId,
-        document: result.source ? withoutEmbedding(result.source) : undefined,
+        document,
+        embeddingPreview: document
+            ? await buildDocumentEmbeddingPreview(index, document)
+            : undefined,
     };
+}
+
+/**
+ * Build the embedding preview for an already-fetched document.
+ *
+ * Returns undefined when the index does not embed at all — a lexical index has
+ * no vector to explain, and showing an empty preview would imply otherwise.
+ */
+async function buildDocumentEmbeddingPreview(
+    index: ResolvedIndex,
+    document: Record<string, unknown>
+): Promise<EmbeddingPreview | undefined> {
+    if (!index.embeddingConfig.enabled) {
+        return undefined;
+    }
+    const vectorSourceFields = await fieldsRepository.getVectorSourceFields(index.id);
+    if (vectorSourceFields.length === 0) {
+        return undefined;
+    }
+    return buildEmbeddingPreview(document, vectorSourceFields);
 }
 
 /**

--- a/backend/src/features/document-indexing/embedding-text.test.ts
+++ b/backend/src/features/document-indexing/embedding-text.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect } from 'vitest';
+
+import { buildEmbeddingPreview, getEmbeddingText } from './embedding-text';
+
+import type { SearchIndexField } from '@/db/schema/search-index-fields.schema';
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+/** Build a minimal vector-source field. Only the columns the builder reads matter. */
+function field(overrides: {
+    fieldName: string;
+    displayName?: string | null;
+    boostValue?: number;
+}): SearchIndexField {
+    return {
+        fieldName: overrides.fieldName,
+        displayName: overrides.displayName ?? null,
+        boostValue: overrides.boostValue ?? 1,
+    } as unknown as SearchIndexField;
+}
+
+// ============================================================================
+// LABELLING
+// ============================================================================
+
+describe('embedding text — labelling', () => {
+    it('prefixes every value with its field label', () => {
+        // A bare "camel" reads as the animal; "Colour: camel" does not.
+        const text = getEmbeddingText(
+            { primaryColor: 'camel' },
+            [field({ fieldName: 'primaryColor', displayName: 'Colour' })]
+        );
+
+        expect(text).toBe('Colour: camel');
+    });
+
+    it('falls back to the field name when there is no display name', () => {
+        const text = getEmbeddingText({ season: 'Summer' }, [field({ fieldName: 'season' })]);
+
+        expect(text).toBe('season: Summer');
+    });
+
+    it('puts each field on its own line', () => {
+        const text = getEmbeddingText(
+            { name: 'Denim Jacket', season: 'Summer' },
+            [field({ fieldName: 'name' }), field({ fieldName: 'season' })]
+        );
+
+        expect(text).toBe('name: Denim Jacket\nseason: Summer');
+    });
+});
+
+// ============================================================================
+// ORDERING
+// ============================================================================
+
+describe('embedding text — ordering', () => {
+    it('orders by boost, not alphabetically', () => {
+        // Alphabetical order buried the product name behind ageGroup and
+        // availableColors; earlier tokens carry more weight in the model.
+        const preview = buildEmbeddingPreview(
+            { ageGroup: 'Adult', availableColors: ['camel'], name: 'Denim Jacket' },
+            [
+                field({ fieldName: 'ageGroup', boostValue: 3 }),
+                field({ fieldName: 'availableColors', boostValue: 3 }),
+                field({ fieldName: 'name', boostValue: 9 }),
+            ]
+        );
+
+        expect(preview.parts.map(p => p.fieldName)).toEqual([
+            'name', 'ageGroup', 'availableColors',
+        ]);
+        expect(preview.text.startsWith('name: Denim Jacket')).toBe(true);
+    });
+
+    it('breaks boost ties on field name so output is stable', () => {
+        const fields = [
+            field({ fieldName: 'season', boostValue: 3 }),
+            field({ fieldName: 'brand', boostValue: 3 }),
+        ];
+        const doc = { season: 'Summer', brand: 'Haven' };
+
+        expect(getEmbeddingText(doc, fields)).toBe(getEmbeddingText(doc, fields));
+        expect(getEmbeddingText(doc, fields)).toBe('brand: Haven\nseason: Summer');
+    });
+
+    it('does not mutate the caller\'s field array', () => {
+        const fields = [
+            field({ fieldName: 'a', boostValue: 1 }),
+            field({ fieldName: 'z', boostValue: 9 }),
+        ];
+
+        getEmbeddingText({ a: 'x', z: 'y' }, fields);
+
+        expect(fields.map(f => f.fieldName)).toEqual(['a', 'z']);
+    });
+});
+
+// ============================================================================
+// VALUE RENDERING
+// ============================================================================
+
+describe('embedding text — value rendering', () => {
+    it('renders arrays as comma-separated lists', () => {
+        const text = getEmbeddingText(
+            { tags: ['classic', 'office', 'summer'] },
+            [field({ fieldName: 'tags' })]
+        );
+
+        expect(text).toBe('tags: classic, office, summer');
+    });
+
+    it('includes numbers and booleans, which the label makes meaningful', () => {
+        const text = getEmbeddingText(
+            { maxPrice: 89.99, inStock: true, hasDiscount: false },
+            [
+                field({ fieldName: 'maxPrice', displayName: 'Price' }),
+                field({ fieldName: 'inStock', displayName: 'In stock' }),
+                field({ fieldName: 'hasDiscount', displayName: 'On sale' }),
+            ]
+        );
+
+        expect(text).toContain('Price: 89.99');
+        expect(text).toContain('In stock: yes');
+        expect(text).toContain('On sale: no');
+    });
+
+    it('trims surrounding whitespace from values', () => {
+        const text = getEmbeddingText({ name: '  Denim Jacket  ' }, [field({ fieldName: 'name' })]);
+
+        expect(text).toBe('name: Denim Jacket');
+    });
+});
+
+// ============================================================================
+// EXCLUSIONS
+// ============================================================================
+
+describe('embedding text — exclusions', () => {
+    it('drops empty arrays instead of emitting a blank part', () => {
+        // The old builder pushed '' for these, so documents began with stray
+        // separators and the text started with whitespace.
+        const preview = buildEmbeddingPreview(
+            { availableColors: [], name: 'Denim Jacket' },
+            [
+                field({ fieldName: 'availableColors', boostValue: 3 }),
+                field({ fieldName: 'name', boostValue: 9 }),
+            ]
+        );
+
+        expect(preview.text).toBe('name: Denim Jacket');
+        expect(preview.parts.find(p => p.fieldName === 'availableColors')).toMatchObject({
+            included: false,
+            excludedBecause: 'empty',
+        });
+    });
+
+    it('reports arrays of objects as unsupported, not empty', () => {
+        // A variants list embeds as SKU and hex-code noise. Calling it "empty"
+        // would suggest this document lacks data, when in fact the field can
+        // never contribute on any document.
+        const preview = buildEmbeddingPreview(
+            { variants: [{ sku: 'X-1', colorHex: '#C19A6B' }] },
+            [field({ fieldName: 'variants' })]
+        );
+
+        expect(preview.text).toBe('');
+        expect(preview.parts[0]).toMatchObject({
+            included: false,
+            excludedBecause: 'unsupported-type',
+        });
+    });
+
+    it('reports plain objects as unsupported', () => {
+        const preview = buildEmbeddingPreview(
+            { customFields: { a: 1 } },
+            [field({ fieldName: 'customFields' })]
+        );
+
+        expect(preview.parts[0]).toMatchObject({
+            included: false,
+            excludedBecause: 'unsupported-type',
+        });
+    });
+
+    it('separates missing values from empty and unsupported ones', () => {
+        // These are three different problems with three different fixes, so a
+        // null field must not be reported as the wrong type.
+        const preview = buildEmbeddingPreview(
+            { absent: null, undef: undefined, blank: '   ', emptyList: [], obj: { a: 1 } },
+            [
+                field({ fieldName: 'absent' }),
+                field({ fieldName: 'undef' }),
+                field({ fieldName: 'blank' }),
+                field({ fieldName: 'emptyList' }),
+                field({ fieldName: 'obj' }),
+            ]
+        );
+
+        const reason = (name: string) =>
+            preview.parts.find(p => p.fieldName === name)?.excludedBecause;
+
+        expect(preview.text).toBe('');
+        expect(reason('absent')).toBe('missing');
+        expect(reason('undef')).toBe('missing');
+        expect(reason('blank')).toBe('empty');
+        expect(reason('emptyList')).toBe('empty');
+        expect(reason('obj')).toBe('unsupported-type');
+    });
+
+    it('excludes non-finite numbers rather than embedding "NaN"', () => {
+        const preview = buildEmbeddingPreview(
+            { price: Number.NaN },
+            [field({ fieldName: 'price' })]
+        );
+
+        expect(preview.text).toBe('');
+        expect(preview.parts[0].included).toBe(false);
+    });
+
+    it('reports every vector-source field, included or not', () => {
+        // The UI lists what contributed nothing — a silently-empty field is
+        // exactly what ruins semantic search unnoticed.
+        const preview = buildEmbeddingPreview(
+            { name: 'Denim Jacket', tags: [] },
+            [field({ fieldName: 'name' }), field({ fieldName: 'tags' })]
+        );
+
+        expect(preview.parts).toHaveLength(2);
+        expect(preview.parts.filter(p => p.included)).toHaveLength(1);
+    });
+});
+
+// ============================================================================
+// PREVIEW PARITY
+// ============================================================================
+
+describe('preview parity', () => {
+    it('getEmbeddingText returns exactly the preview text', () => {
+        // The admin UI shows the preview; if these diverge it shows a lie.
+        const fields = [
+            field({ fieldName: 'name', boostValue: 9 }),
+            field({ fieldName: 'tags', boostValue: 2 }),
+            field({ fieldName: 'variants', boostValue: 3 }),
+            field({ fieldName: 'maxPrice', boostValue: 1 }),
+        ];
+        const doc = {
+            name: 'Denim Jacket',
+            tags: ['classic', 'office'],
+            variants: [{ sku: 'X-1' }],
+            maxPrice: 89.99,
+        };
+
+        const preview = buildEmbeddingPreview(doc, fields);
+
+        expect(getEmbeddingText(doc, fields)).toBe(preview.text);
+        expect(preview.totalChars).toBe(preview.text.length);
+    });
+
+    it('reports zero characters for a document with nothing embeddable', () => {
+        const preview = buildEmbeddingPreview({ tags: [] }, [field({ fieldName: 'tags' })]);
+
+        expect(preview.text).toBe('');
+        expect(preview.totalChars).toBe(0);
+    });
+});

--- a/backend/src/features/document-indexing/embedding-text.ts
+++ b/backend/src/features/document-indexing/embedding-text.ts
@@ -1,0 +1,192 @@
+// src/features/document-indexing/embedding-text.ts
+
+/**
+ * Embedding Text Construction
+ *
+ * Builds the text that gets sent to the embedding model for a document.
+ *
+ * The text is assembled from the fields marked `isVectorSource`, and three
+ * decisions shape how well the resulting vector works:
+ *
+ * 1. **Fields are labelled.** A bare `"camel"` or `"Adult"` in a blob of
+ *    fragments is semantic mush — "camel" reads as the animal. `Colour: camel`
+ *    tells the model what it is looking at.
+ * 2. **Order follows configured importance, not the alphabet.** Embedding models
+ *    weight earlier tokens more heavily, so the fields the operator boosted for
+ *    search lead. Sorting by field name buried the product name in the middle of
+ *    the text.
+ * 3. **Empty parts are dropped entirely.** An array that filters to nothing used
+ *    to contribute a blank separator, so documents began with stray whitespace.
+ *
+ * Kept free of db/provider imports so it can be tested directly and reused by
+ * the preview endpoint.
+ */
+
+import type { SearchIndexField } from '@/db/schema/search-index-fields.schema';
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+/**
+ * Why a vector-source field contributed nothing to the text.
+ *
+ * The three are distinct problems with distinct fixes, so they are reported
+ * separately rather than lumped together:
+ * - `missing` — the source data has no value here; fix the ingest or the mapping
+ * - `empty` — a value exists but is blank, e.g. `[]` or `"  "`
+ * - `unsupported-type` — an object or list of objects, which cannot be embedded
+ *   at all; that field will never contribute, on any document
+ */
+export type EmbeddingPartExclusion = 'missing' | 'empty' | 'unsupported-type';
+
+export interface EmbeddingTextPart {
+    fieldName: string;
+    /** Human label used as the prefix in the text. */
+    label: string;
+    /** The rendered `Label: value` line, or '' when excluded. */
+    text: string;
+    included: boolean;
+    /** Present only when `included` is false. */
+    excludedBecause?: EmbeddingPartExclusion;
+}
+
+export interface EmbeddingPreview {
+    /** Exactly the string handed to the embedding model. */
+    text: string;
+    totalChars: number;
+    /** Every vector-source field, in the order it is considered. */
+    parts: EmbeddingTextPart[];
+}
+
+// ============================================================================
+// RENDERING
+// ============================================================================
+
+/**
+ * Order fields by how much they matter, most important first.
+ *
+ * `boostValue` is the operator's existing statement of field importance for
+ * search, so it is reused here rather than inventing a second ranking to keep in
+ * sync. Ties break on field name so the output is stable across runs.
+ */
+function byImportance(a: SearchIndexField, b: SearchIndexField): number {
+    const boostDelta = (b.boostValue ?? 1) - (a.boostValue ?? 1);
+    return boostDelta !== 0 ? boostDelta : a.fieldName.localeCompare(b.fieldName);
+}
+
+/** A rendered value, or the reason there isn't one. */
+type RenderResult =
+    | { kind: 'value'; text: string }
+    | { kind: 'excluded'; reason: EmbeddingPartExclusion };
+
+/**
+ * Render a single field value as the text after its label.
+ *
+ * Distinguishes carefully between a field that is absent, one that is present
+ * but blank, and one whose type can never be embedded — a field reported as the
+ * wrong type when it is merely null sends whoever is debugging after the wrong
+ * problem entirely.
+ *
+ * Numbers and booleans are included because the label gives them meaning:
+ * `In stock: yes` is a phrase the model can use, where a bare `true` is not.
+ */
+function renderValue(value: unknown): RenderResult {
+    if (value === null || value === undefined) {
+        return { kind: 'excluded', reason: 'missing' };
+    }
+    if (typeof value === 'string') {
+        const trimmed = value.trim();
+        return trimmed.length > 0
+            ? { kind: 'value', text: trimmed }
+            : { kind: 'excluded', reason: 'empty' };
+    }
+    if (typeof value === 'number') {
+        // NaN/Infinity would embed as literal "NaN", which is worse than nothing.
+        return Number.isFinite(value)
+            ? { kind: 'value', text: String(value) }
+            : { kind: 'excluded', reason: 'empty' };
+    }
+    if (typeof value === 'boolean') {
+        return { kind: 'value', text: value ? 'yes' : 'no' };
+    }
+    if (Array.isArray(value)) {
+        if (value.length === 0) {
+            return { kind: 'excluded', reason: 'empty' };
+        }
+        // Comma-separated reads as a list; space-joined ran the values together.
+        const primitives = value
+            .filter(entry => typeof entry === 'string' || typeof entry === 'number')
+            .map(entry => String(entry).trim())
+            .filter(entry => entry.length > 0);
+
+        if (primitives.length > 0) {
+            return { kind: 'value', text: primitives.join(', ') };
+        }
+        // Held entries, but none embeddable — a variants list of objects. That is
+        // a property of the field, not of this document.
+        return { kind: 'excluded', reason: 'unsupported-type' };
+    }
+    // Plain object.
+    return { kind: 'excluded', reason: 'unsupported-type' };
+}
+
+/**
+ * Build the embedding text for a document, with a per-field breakdown.
+ *
+ * The breakdown exists so the admin UI can show exactly what was embedded and,
+ * just as usefully, what was not — a field silently contributing nothing is the
+ * kind of thing that quietly ruins semantic search.
+ *
+ * @param document - The transformed (post-mapping) document
+ * @param vectorSourceFields - Fields with isVectorSource = true
+ */
+export function buildEmbeddingPreview(
+    document: Record<string, unknown>,
+    vectorSourceFields: SearchIndexField[]
+): EmbeddingPreview {
+    const parts: EmbeddingTextPart[] = [];
+
+    for (const field of [...vectorSourceFields].sort(byImportance)) {
+        const label = field.displayName || field.fieldName;
+        const rendered = renderValue(document[field.fieldName]);
+
+        if (rendered.kind === 'excluded') {
+            parts.push({
+                fieldName: field.fieldName,
+                label,
+                text: '',
+                included: false,
+                excludedBecause: rendered.reason,
+            });
+            continue;
+        }
+
+        parts.push({
+            fieldName: field.fieldName,
+            label,
+            text: `${label}: ${rendered.text}`,
+            included: true,
+        });
+    }
+
+    const text = parts
+        .filter(part => part.included)
+        .map(part => part.text)
+        .join('\n');
+
+    return { text, totalChars: text.length, parts };
+}
+
+/**
+ * The text sent to the embedding model for a document.
+ *
+ * Thin wrapper over buildEmbeddingPreview so the preview shown in the admin UI
+ * can never drift from what is actually embedded.
+ */
+export function getEmbeddingText(
+    document: Record<string, unknown>,
+    vectorSourceFields: SearchIndexField[]
+): string {
+    return buildEmbeddingPreview(document, vectorSourceFields).text;
+}

--- a/backend/src/features/pipeline/v2/action-steps/action-step.types.ts
+++ b/backend/src/features/pipeline/v2/action-steps/action-step.types.ts
@@ -73,6 +73,22 @@ export interface ActionStepContext {
   toolResult: ToolExecutionResultV2 | null;
   /** Final parameters used (may differ from validatedParams after retry relaxation) */
   finalParams: Record<string, unknown> | null;
+  /**
+   * Constraints the retry step had to abandon to get any results at all.
+   *
+   * Set only when relaxation actually changed the request. Without this the
+   * pipeline answers a question the user did not ask — dropping "under $60" and
+   * returning full-price items reads as a broken filter, not a narrowed search.
+   */
+  relaxation?: FilterRelaxation;
+}
+
+/** What a zero-result retry gave up in order to return something. */
+export interface FilterRelaxation {
+  /** Human-readable `field=value` pairs that were dropped. */
+  droppedFilters: string[];
+  /** True when every filter was abandoned and the values folded into the query. */
+  droppedAll: boolean;
 }
 
 // ============================================================================

--- a/backend/src/features/pipeline/v2/action-steps/zero-result-retry.step.test.ts
+++ b/backend/src/features/pipeline/v2/action-steps/zero-result-retry.step.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+
+import { ZeroResultRetryStep } from './zero-result-retry.step';
+
+import type { ActionStepContext, ActionStepDeps } from './action-step.types';
+import type { ToolExecutionResultV2 } from '../v2.types';
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+const empty: ToolExecutionResultV2 = { success: true, data: { results: [] }, resultCount: 0 };
+const hit = (n: number): ToolExecutionResultV2 => ({
+    success: true,
+    data: { results: Array.from({ length: n }, (_, i) => ({ id: i })) },
+    resultCount: n,
+});
+
+/**
+ * Build a context for a search that came back empty with filters applied —
+ * the only situation this step acts on.
+ */
+function context(filters: Array<{ field: string; operator: string; value: unknown }>): ActionStepContext {
+    return {
+        action: { toolSlug: 'catalog-search', intent: 'find items' },
+        toolId: 'tool-1',
+        toolResult: empty,
+        finalParams: { query: 'mens t-shirt', filters },
+        validatedParams: null,
+        extractedParams: null,
+    } as unknown as ActionStepContext;
+}
+
+/**
+ * Deps whose executor answers according to `respond`, so a test can decide which
+ * relaxation attempt finally succeeds.
+ */
+function deps(respond: (params: Record<string, unknown>) => ToolExecutionResultV2): ActionStepDeps {
+    return {
+        chat: (async () => ({ content: '' })) as unknown as ActionStepDeps['chat'],
+        executeTool: async (_id: string, _slug: string, params: Record<string, unknown>) => respond(params),
+        emit: () => {},
+        config: {} as ActionStepDeps['config'],
+    };
+}
+
+const filterCount = (params: Record<string, unknown>) =>
+    Array.isArray(params.filters) ? (params.filters as unknown[]).length : 0;
+
+// ============================================================================
+// TESTS
+// ============================================================================
+
+describe('ZeroResultRetryStep — reporting what it gave up', () => {
+    it('reports the filter it dropped to get results', async () => {
+        // "under $60" matched nothing, so the price filter is dropped. Returning
+        // full-price items without saying so reads as a broken filter.
+        const step = new ZeroResultRetryStep();
+        const ctx = context([
+            { field: 'gender', operator: 'eq', value: 'Men' },
+            { field: 'maxPrice', operator: 'lte', value: 60 },
+        ]);
+
+        const result = await step.execute(ctx, deps(params => (filterCount(params) < 2 ? hit(7) : empty)));
+
+        expect(result.context.relaxation).toBeDefined();
+        expect(result.context.relaxation?.droppedFilters).toEqual(['maxPrice=60']);
+        expect(result.context.relaxation?.droppedAll).toBe(false);
+    });
+
+    it('flags when every filter was abandoned', async () => {
+        const step = new ZeroResultRetryStep();
+        const ctx = context([
+            { field: 'gender', operator: 'eq', value: 'Men' },
+            { field: 'maxPrice', operator: 'lte', value: 60 },
+        ]);
+
+        // Only the no-filter semantic fallback returns anything.
+        const result = await step.execute(ctx, deps(params => (filterCount(params) === 0 ? hit(20) : empty)));
+
+        expect(result.context.relaxation?.droppedAll).toBe(true);
+        expect(result.context.relaxation?.droppedFilters).toEqual(
+            expect.arrayContaining(['gender=Men', 'maxPrice=60'])
+        );
+    });
+
+    it('reports nothing when no relaxation was needed', async () => {
+        const step = new ZeroResultRetryStep();
+        const ctx = {
+            ...context([{ field: 'gender', operator: 'eq', value: 'Men' }]),
+            toolResult: hit(11),
+        } as ActionStepContext;
+
+        const result = await step.execute(ctx, deps(() => hit(11)));
+
+        expect(result.context.relaxation).toBeUndefined();
+    });
+
+    it('reports nothing when relaxation failed to find anything either', async () => {
+        // Every attempt is empty, so the original filters still stand — there is
+        // no wrong answer to warn about, just an empty result set.
+        const step = new ZeroResultRetryStep();
+        const ctx = context([{ field: 'gender', operator: 'eq', value: 'Men' }]);
+
+        const result = await step.execute(ctx, deps(() => empty));
+
+        expect(result.context.relaxation).toBeUndefined();
+    });
+
+    it('records the dropped filters on the span', async () => {
+        const step = new ZeroResultRetryStep();
+        const ctx = context([
+            { field: 'gender', operator: 'eq', value: 'Men' },
+            { field: 'maxPrice', operator: 'lte', value: 60 },
+        ]);
+
+        const result = await step.execute(ctx, deps(params => (filterCount(params) < 2 ? hit(7) : empty)));
+
+        expect(result.spanAttributes?.['alpha.v2.step.dropped_filters']).toBe(
+            JSON.stringify(['maxPrice=60'])
+        );
+    });
+});

--- a/backend/src/features/pipeline/v2/action-steps/zero-result-retry.step.ts
+++ b/backend/src/features/pipeline/v2/action-steps/zero-result-retry.step.ts
@@ -150,12 +150,26 @@ export class ZeroResultRetryStep implements ActionStep {
       ? `Retry succeeded at ${lastSuccessful!.step}: ${summaryParts.join('; ')}`
       : `0 results after ${retryLog.length} relaxation attempt(s): ${summaryParts.join('; ')}`;
 
+    // Work out what the user asked for that we could not honour. Comparing the
+    // final filter set against the original is more reliable than tracking each
+    // relaxation branch, and covers the semantic fallback that drops them all.
+    const finalFilters = (finalParams.filters ?? []) as Array<{ field: string; value: unknown }>;
+    const finalKeys = new Set(finalFilters.map((f) => `${f.field}=${f.value}`));
+    const droppedFilters = originalFilters
+      .map((f) => `${f.field}=${f.value}`)
+      .filter((key) => !finalKeys.has(key));
+
+    const relaxation = droppedFilters.length > 0
+      ? { droppedFilters, droppedAll: finalFilters.length === 0 }
+      : undefined;
+
     return {
       success: true,
       context: {
         ...ctx,
         toolResult,
         finalParams,
+        ...(relaxation && { relaxation }),
       },
       summary,
       durationMs,
@@ -164,6 +178,9 @@ export class ZeroResultRetryStep implements ActionStep {
         'alpha.v2.step.original_filters': JSON.stringify(originalFilters.map((f) => `${f.field}=${f.value}`)),
         'alpha.v2.step.retry_attempts': retryLog.length,
         'alpha.v2.step.retry_succeeded': succeeded,
+        ...(relaxation && {
+          'alpha.v2.step.dropped_filters': JSON.stringify(relaxation.droppedFilters),
+        }),
         'alpha.v2.step.retry_log': JSON.stringify(retryLog),
         ...(finalParams.query !== originalQuery && { 'alpha.v2.step.final_query': String(finalParams.query) }),
         ...(finalParams.filters !== params.filters && {

--- a/backend/src/features/pipeline/v2/action-steps/zero-result-retry.step.ts
+++ b/backend/src/features/pipeline/v2/action-steps/zero-result-retry.step.ts
@@ -153,11 +153,12 @@ export class ZeroResultRetryStep implements ActionStep {
     // Work out what the user asked for that we could not honour. Comparing the
     // final filter set against the original is more reliable than tracking each
     // relaxation branch, and covers the semantic fallback that drops them all.
-    const finalFilters = (finalParams.filters ?? []) as Array<{ field: string; value: unknown }>;
-    const finalKeys = new Set(finalFilters.map((f) => `${f.field}=${f.value}`));
+    const finalFilters = (finalParams.filters ?? []) as Array<{ field: string; operator?: string; value: unknown }>;
+    const keyOf = (f: { field: string; operator?: string; value: unknown }) => `${f.field}|${f.operator ?? ''}|${String(f.value)}`;
+    const finalKeys = new Set(finalFilters.map(keyOf));
     const droppedFilters = originalFilters
-      .map((f) => `${f.field}=${f.value}`)
-      .filter((key) => !finalKeys.has(key));
+      .filter((f) => !finalKeys.has(keyOf(f)))
+      .map((f) => `${f.field}=${f.value}`);
 
     const relaxation = droppedFilters.length > 0
       ? { droppedFilters, droppedAll: finalFilters.length === 0 }

--- a/backend/src/features/pipeline/v2/execution-loop.ts
+++ b/backend/src/features/pipeline/v2/execution-loop.ts
@@ -163,6 +163,7 @@ export async function executeLoop(
         parameters: finalContext.finalParams ?? finalContext.validatedParams ?? finalContext.extractedParams ?? {},
         result: finalContext.toolResult ?? { success: false, data: null, error: 'No tool result' },
         durationMs: Date.now() - actionStart,
+        ...(finalContext.relaxation && { relaxation: finalContext.relaxation }),
       };
 
       executedActions.push(actionResult);

--- a/backend/src/features/pipeline/v2/param-extraction.ts
+++ b/backend/src/features/pipeline/v2/param-extraction.ts
@@ -382,8 +382,17 @@ Required: ${requiredFields}
    The query field should contain the **descriptive terms** that define what the user is looking for.
    KEEP in the query: product type, descriptive qualifiers (e.g., "left-handed", "wireless", "leather", "organic", "waterproof").
    MOVE to filters: structured attributes that match a filter field (e.g., gender, brand, price range, size, color when a color filter exists).
-   Example: "men's left-handed leather golf gloves under $100" → query: "left-handed leather golf gloves", filters: gender=Men + maxPrice≤100.
-   When in doubt, keep the term in the query — an overly narrow query returns zero results, while a slightly broad query can still be filtered.`;
+   Example: "men's left-handed leather golf gloves under $100" → query: "left-handed leather golf gloves", filters: gender=Men + minPrice≤100.
+   When in doubt, keep the term in the query — an overly narrow query returns zero results, while a slightly broad query can still be filtered.
+9. IMPORTANT — paired range fields (e.g. minPrice/maxPrice):
+   A pair like minPrice/maxPrice describes ONE item's range across its variants — they are not
+   two separate prices to choose between. minPrice is the cheapest variant, maxPrice the dearest.
+   "under $X" / "below $X" / "cheaper than $X" → filter the LOWER bound: minPrice ≤ X.
+     The user wants something they can buy for under $X, so it is enough that one variant qualifies.
+     Filtering maxPrice ≤ X demands that EVERY variant is under $X and almost always returns nothing.
+   "over $X" / "above $X" → filter the UPPER bound: maxPrice ≥ X.
+   "between $X and $Y" → minPrice ≤ Y and maxPrice ≥ X.
+   If only one of the pair is offered as a filter field, use that one rather than skipping the filter.`;
 
   if (fieldConstraints) {
     prompt += `\n\n## Filter field constraints\nWhen building filters, you MUST use one of the exact valid values listed below. Pick the value that best matches the user's intent.\n${fieldConstraints}`;

--- a/backend/src/features/pipeline/v2/response-synthesis.ts
+++ b/backend/src/features/pipeline/v2/response-synthesis.ts
@@ -393,7 +393,7 @@ async function synthesizeFromResults(
   const persona = input.personaConfig;
 
   // Build what-was-done summary
-  const actionSummary = input.actionResults
+  const actionSummaryLines = input.actionResults
     .map((a) => {
       let status: string;
       if (!a.result.success) {
@@ -404,9 +404,27 @@ async function synthesizeFromResults(
       } else {
         status = `${a.result.resultCount ?? 0} results`;
       }
-      return `- ${a.toolSlug}: ${a.intent} → ${status}`;
+      const relaxed = a.relaxation
+        ? ` — NOTE: no results matched ${a.relaxation.droppedFilters.join(', ')}, `
+          + `so ${a.relaxation.droppedAll ? 'all filters were' : 'that constraint was'} `
+          + 'dropped and these results DO NOT satisfy it'
+        : '';
+      return `- ${a.toolSlug}: ${a.intent} → ${status}${relaxed}`;
     })
     .join('\n');
+
+  // Relaxation must reach the model as an instruction, not a footnote: returning
+  // full-price items for "under $60" without saying so is a wrong answer, and the
+  // user reads it as a broken filter rather than an empty result set.
+  //
+  // Appended to actionSummary rather than passed as its own variable so it reaches
+  // both prompt paths — the DB-backed template renders a fixed set of variables and
+  // would silently drop a new one.
+  const actionSummary = input.actionResults.some((a) => a.relaxation)
+    ? `${actionSummaryLines}\n\nIMPORTANT — some constraints could not be met. Say so `
+      + 'plainly and early in your answer: state which constraint returned nothing, and '
+      + 'make clear the items shown do not satisfy it. Do not present them as if they matched.'
+    : actionSummaryLines;
 
   // Build result data (truncated to avoid token bloat)
   const resultData = input.actionResults

--- a/backend/src/features/pipeline/v2/v2.types.ts
+++ b/backend/src/features/pipeline/v2/v2.types.ts
@@ -291,6 +291,12 @@ export interface ActionResult {
   parameters: Record<string, unknown>;
   result: ToolExecutionResultV2;
   durationMs: number;
+  /**
+   * Constraints abandoned by zero-result retry, if any. Surfaced to synthesis so
+   * the answer can say what it could not honour instead of silently returning
+   * results that do not match the request.
+   */
+  relaxation?: { droppedFilters: string[]; droppedAll: boolean };
 }
 
 export interface ToolExecutionResultV2 {

--- a/backend/src/features/prompt-templates/prompt-template.defaults.ts
+++ b/backend/src/features/prompt-templates/prompt-template.defaults.ts
@@ -105,8 +105,17 @@ Required: {{requiredFields}}
    The query field should contain the **descriptive terms** that define what the user is looking for.
    KEEP in the query: product type, descriptive qualifiers (e.g., "left-handed", "wireless", "leather", "organic", "waterproof").
    MOVE to filters: structured attributes that match a filter field (e.g., gender, brand, price range, size, color when a color filter exists).
-   Example: "men's left-handed leather golf gloves under $100" → query: "left-handed leather golf gloves", filters: gender=Men + maxPrice≤100.
+   Example: "men's left-handed leather golf gloves under $100" → query: "left-handed leather golf gloves", filters: gender=Men + minPrice≤100.
    When in doubt, keep the term in the query — an overly narrow query returns zero results, while a slightly broad query can still be filtered.
+9. IMPORTANT — paired range fields (e.g. minPrice/maxPrice):
+   A pair like minPrice/maxPrice describes ONE item's range across its variants — they are not
+   two separate prices to choose between. minPrice is the cheapest variant, maxPrice the dearest.
+   "under $X" / "below $X" / "cheaper than $X" → filter the LOWER bound: minPrice ≤ X.
+     The user wants something they can buy for under $X, so it is enough that one variant qualifies.
+     Filtering maxPrice ≤ X demands that EVERY variant is under $X and almost always returns nothing.
+   "over $X" / "above $X" → filter the UPPER bound: maxPrice ≥ X.
+   "between $X and $Y" → minPrice ≤ Y and maxPrice ≥ X.
+   If only one of the pair is offered as a filter field, use that one rather than skipping the filter.
 <!-- /section:rules -->
 
 {{#if fieldConstraints}}

--- a/backend/src/features/prompt-templates/prompt-template.repository.ts
+++ b/backend/src/features/prompt-templates/prompt-template.repository.ts
@@ -74,6 +74,26 @@ export async function create(data: NewPromptTemplate) {
   return row;
 }
 
+/**
+ * Overwrite a seeded system-default template's content in place.
+ *
+ * Used only by seedSystemDefaults to bring an untouched v1 seed row back in line
+ * with the code-defined default. User-authored versions are separate rows and are
+ * never rewritten — see the guard in seedSystemDefaults.
+ */
+export async function updateContent(
+  id: string,
+  data: { label?: string | null; content: string; metadata: NewPromptTemplate['metadata'] },
+) {
+  const [row] = await db
+    .update(promptTemplates)
+    .set({ ...data, updatedAt: new Date() })
+    .where(eq(promptTemplates.id, id))
+    .returning();
+  logger.info('Prompt template content updated', { id: row.id, step: row.step });
+  return row;
+}
+
 export async function updateStatus(id: string, status: 'draft' | 'active' | 'archived') {
   const [row] = await db
     .update(promptTemplates)

--- a/backend/src/features/prompt-templates/prompt-template.repository.ts
+++ b/backend/src/features/prompt-templates/prompt-template.repository.ts
@@ -90,6 +90,10 @@ export async function updateContent(
     .set({ ...data, updatedAt: new Date() })
     .where(eq(promptTemplates.id, id))
     .returning();
+
+  if (!row) {
+    throw new Error(`Prompt template not found: ${id}`);
+  }
   logger.info('Prompt template content updated', { id: row.id, step: row.step });
   return row;
 }

--- a/backend/src/features/prompt-templates/prompt-template.service.ts
+++ b/backend/src/features/prompt-templates/prompt-template.service.ts
@@ -161,17 +161,41 @@ export async function removeExperienceOverride(experienceId: string, step: Promp
 
 /**
  * Seed system default prompt templates from the code-defined defaults.
- * Idempotent — only creates rows that don't already exist.
- * Called at application startup.
+ *
+ * Creates missing rows, and re-syncs untouched seed rows whose content has since
+ * changed in code. Called at application startup.
+ *
+ * The re-sync matters: this used to be insert-only, which meant editing a default
+ * in code had no effect on any existing installation — the stale row kept winning
+ * at resolve time, silently, forever. A prompt fix that cannot reach a running
+ * system is not a fix.
+ *
+ * Only a pristine seed row is rewritten — `version: 1` with no `parentId`. A
+ * user-authored version that was promoted to system default has a parent or a
+ * higher version, and is left alone; overwriting someone's deliberate prompt with
+ * a platform default would be far worse than a stale default.
  */
 export async function seedSystemDefaults() {
   let created = 0;
+  let updated = 0;
   let skipped = 0;
 
   for (const def of SYSTEM_DEFAULT_TEMPLATES) {
     const existing = await repo.getSystemDefault(def.step);
+
     if (existing) {
-      skipped++;
+      const isPristineSeed = existing.version === 1 && !existing.parentId;
+
+      if (isPristineSeed && existing.content !== def.content) {
+        await repo.updateContent(existing.id, {
+          label: def.label,
+          content: def.content,
+          metadata: def.metadata,
+        });
+        updated++;
+      } else {
+        skipped++;
+      }
       continue;
     }
 
@@ -188,8 +212,11 @@ export async function seedSystemDefaults() {
     created++;
   }
 
-  if (created > 0) {
-    logger.info('Seeded prompt templates', { created, skipped });
+  if (created > 0 || updated > 0) {
+    // Resolved templates are cached; a rewritten row would otherwise keep
+    // serving its old content for the life of the process.
+    invalidateTemplateCache();
+    logger.info('Seeded prompt templates', { created, updated, skipped });
   } else {
     logger.debug('All prompt templates already seeded', { skipped });
   }

--- a/backend/src/features/search-experience/query-interpreter.core.test.ts
+++ b/backend/src/features/search-experience/query-interpreter.core.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+    buildInterpreterPrompt,
+    parseInterpretation,
+    shouldInterpret,
+    toParameterContext,
+} from './query-interpreter.core';
+
+import type { FieldConstraint } from '@/features/pipeline/v2/parameter-context.types';
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+function constraint(overrides: Partial<FieldConstraint> & { fieldName: string }): FieldConstraint {
+    return {
+        fieldType: 'text',
+        isFilterable: true,
+        isFacetable: true,
+        validValues: [],
+        ...overrides,
+    };
+}
+
+const CONSTRAINTS: Record<string, FieldConstraint> = {
+    gender: constraint({ fieldName: 'gender', validValues: ['Men', 'Women', 'Unisex'] }),
+    minPrice: constraint({ fieldName: 'minPrice', fieldType: 'number', isFacetable: false }),
+    secret: constraint({ fieldName: 'secret', isFilterable: false }),
+};
+
+// ============================================================================
+// GATING
+// ============================================================================
+
+describe('shouldInterpret', () => {
+    it('interprets a phrase at or above the word threshold', () => {
+        expect(shouldInterpret('men t-shirt below 110', 3)).toBe(true);
+    });
+
+    it('skips a bare keyword lookup', () => {
+        // Not worth an LLM round trip on every keystroke.
+        expect(shouldInterpret('sweatshirt', 3)).toBe(false);
+        expect(shouldInterpret('blue shirt', 3)).toBe(false);
+    });
+
+    it('still interprets a short phrase that carries a comparison', () => {
+        expect(shouldInterpret('under $50', 3)).toBe(true);
+        expect(shouldInterpret('over 4', 3)).toBe(true);
+    });
+
+    it('does not treat a number alone as a comparison', () => {
+        expect(shouldInterpret('shirt 2024', 3)).toBe(false);
+    });
+
+    it('respects a configured threshold', () => {
+        expect(shouldInterpret('blue shirt', 2)).toBe(true);
+    });
+});
+
+// ============================================================================
+// PROMPT
+// ============================================================================
+
+describe('buildInterpreterPrompt', () => {
+    it('lists filterable fields with their real values', () => {
+        // Grounding in actual values is what turns "mens" into "Men".
+        const prompt = buildInterpreterPrompt(CONSTRAINTS);
+
+        expect(prompt).toContain('gender (text)');
+        expect(prompt).toContain('"Men"');
+        expect(prompt).toContain('minPrice (number)');
+    });
+
+    it('omits fields that cannot be filtered', () => {
+        const prompt = buildInterpreterPrompt(CONSTRAINTS);
+
+        expect(prompt).not.toContain('secret');
+    });
+
+    it('teaches the paired-range rule', () => {
+        // The whole point: "under $X" must filter the lower bound.
+        const prompt = buildInterpreterPrompt(CONSTRAINTS);
+
+        expect(prompt).toContain('minPrice <= X');
+        expect(prompt).toContain('maxPrice >= X');
+    });
+
+    it('appends custom instructions when configured', () => {
+        const prompt = buildInterpreterPrompt(CONSTRAINTS, 'Prefer in-stock items.');
+
+        expect(prompt).toContain('Prefer in-stock items.');
+    });
+});
+
+// ============================================================================
+// PARSING
+// ============================================================================
+
+describe('parseInterpretation', () => {
+    it('parses a query and filters', () => {
+        const result = parseInterpretation(
+            JSON.stringify({
+                query: 't-shirt',
+                filters: [
+                    { field: 'gender', operator: 'eq', value: 'Men' },
+                    { field: 'minPrice', operator: 'lte', value: 110 },
+                ],
+            }),
+            'men t-shirt below $110',
+        );
+
+        expect(result).toEqual({
+            query: 't-shirt',
+            filters: [
+                { field: 'gender', operator: 'eq', value: 'Men' },
+                { field: 'minPrice', operator: 'lte', value: 110 },
+            ],
+        });
+    });
+
+    it('coerces numeric strings, including currency symbols', () => {
+        // Models return "$110" despite instructions; a string where a range query
+        // expects a number matches nothing.
+        const result = parseInterpretation(
+            JSON.stringify({ query: 'shirt', filters: [{ field: 'minPrice', operator: 'lte', value: '$110' }] }),
+            'shirt under $110',
+        );
+
+        expect(result?.filters[0].value).toBe(110);
+    });
+
+    it('keeps genuinely textual values as strings', () => {
+        const result = parseInterpretation(
+            JSON.stringify({ query: 'shirt', filters: [{ field: 'gender', operator: 'eq', value: 'Men' }] }),
+            'mens shirt',
+        );
+
+        expect(result?.filters[0].value).toBe('Men');
+    });
+
+    it('falls back to the original query when the model returns an empty one', () => {
+        // An empty query would match the entire index.
+        const result = parseInterpretation(
+            JSON.stringify({ query: '   ', filters: [] }),
+            'mens shirt',
+        );
+
+        expect(result?.query).toBe('mens shirt');
+    });
+
+    it('drops malformed filter entries rather than failing the whole parse', () => {
+        const result = parseInterpretation(
+            JSON.stringify({
+                query: 'shirt',
+                filters: [
+                    { field: 'gender', operator: 'eq', value: 'Men' },
+                    { field: 'gender' },
+                    { field: 'x', operator: 'explode', value: 1 },
+                    null,
+                    { field: 'y', operator: 'eq', value: null },
+                ],
+            }),
+            'shirt',
+        );
+
+        expect(result?.filters).toEqual([{ field: 'gender', operator: 'eq', value: 'Men' }]);
+    });
+
+    it('returns null on unparseable output so the caller can fall back', () => {
+        expect(parseInterpretation('not json', 'shirt')).toBeNull();
+        expect(parseInterpretation('"a string"', 'shirt')).toBeNull();
+    });
+
+    it('tolerates a missing filters array', () => {
+        const result = parseInterpretation(JSON.stringify({ query: 'shirt' }), 'shirt');
+
+        expect(result).toEqual({ query: 'shirt', filters: [] });
+    });
+});
+
+// ============================================================================
+// CONTEXT
+// ============================================================================
+
+describe('toParameterContext', () => {
+    it('marks a populated context as enriched', () => {
+        const ctx = toParameterContext(CONSTRAINTS);
+
+        expect(ctx.enriched).toBe(true);
+        expect(ctx.fieldConstraints.gender.validValues).toContain('Men');
+    });
+
+    it('marks an empty context as not enriched', () => {
+        // validateFilters short-circuits on an empty constraint map, so filters
+        // pass through untouched rather than all being dropped.
+        expect(toParameterContext({}).enriched).toBe(false);
+    });
+});

--- a/backend/src/features/search-experience/query-interpreter.core.ts
+++ b/backend/src/features/search-experience/query-interpreter.core.ts
@@ -1,0 +1,242 @@
+// src/features/search-experience/query-interpreter.core.ts
+
+/**
+ * Query Interpreter — pure core
+ *
+ * Turns a typed search phrase into a cleaned query plus structured filters:
+ *
+ *   "show only items from the men T-shirt below $110"
+ *     → query "t-shirt", filters gender=Men, minPrice<=110
+ *
+ * Without this, a search box can only ever match those words as text — "$110" is
+ * a token to match, not a number to compare — so a price or gender phrase silently
+ * does nothing.
+ *
+ * Everything here is pure: prompt construction, response parsing, and the decision
+ * of whether a query is even worth interpreting. The LLM call, caching and field
+ * loading live in query-interpreter.ts so this half can be tested directly.
+ */
+
+import type { FieldConstraint, ParameterContext } from '@/features/pipeline/v2/parameter-context.types';
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+export interface InterpretedFilter {
+    field: string;
+    operator: string;
+    value: unknown;
+}
+
+export interface ParsedInterpretation {
+    query: string;
+    filters: InterpretedFilter[];
+}
+
+/** Operators the interpreter may emit, mirroring the search filter contract. */
+export const INTERPRETER_OPERATORS = [
+    'eq', 'neq', 'gt', 'gte', 'lt', 'lte', 'in', 'contains',
+] as const;
+
+// ============================================================================
+// GATING
+// ============================================================================
+
+/**
+ * Whether a query is worth an LLM round trip.
+ *
+ * A one- or two-word lookup ("sweatshirt") has no filters to find, and paying for
+ * a model call on every keystroke of a type-ahead box is the fastest way to make
+ * search feel slow and cost real money.
+ */
+export function shouldInterpret(query: string, minWords: number): boolean {
+    const words = query.trim().split(/\s+/).filter(Boolean);
+    if (words.length >= minWords) {
+        return true;
+    }
+    // A short query can still carry a constraint worth extracting — "under $50",
+    // "over 4 stars" — so look for comparison language before giving up.
+    return /\d/.test(query) && /\b(under|below|over|above|less|more|cheaper|max|min)\b/i.test(query);
+}
+
+// ============================================================================
+// PROMPT
+// ============================================================================
+
+/**
+ * Describe the filterable fields, and for text fields the values that actually
+ * exist, so the model picks a real field with a real value rather than inventing
+ * `color=navy` for an index whose values are `Navy Blue`.
+ */
+function describeFields(constraints: Record<string, FieldConstraint>): string {
+    const lines: string[] = [];
+
+    for (const c of Object.values(constraints)) {
+        if (!c.isFilterable) continue;
+
+        const values = c.validValues.length > 0
+            ? ` — valid values: ${c.validValues.slice(0, 40).map(v => `"${v}"`).join(', ')}`
+              + (c.validValues.length > 40 ? ', …' : '')
+            : '';
+        lines.push(`- ${c.fieldName} (${c.fieldType})${values}`);
+    }
+
+    return lines.join('\n');
+}
+
+/**
+ * Build the interpreter instructions.
+ *
+ * The range guidance is the part that matters most on a product catalogue: a
+ * min/max price pair describes one item's span, so "under $X" has to filter the
+ * lower bound. Filtering the upper bound demands that every variant is under $X
+ * and returns almost nothing.
+ */
+export function buildInterpreterPrompt(
+    constraints: Record<string, FieldConstraint>,
+    customInstructions?: string,
+): string {
+    let prompt = `You convert a shopper's search phrase into a search query plus structured filters.
+
+## Filterable fields
+${describeFields(constraints)}
+
+## Rules
+1. **query** — keep only the descriptive terms that say what the user is looking for
+   (product type and qualifiers such as "waterproof", "leather", "long sleeve").
+   Strip filler like "show me", "only", "items from", "I want".
+2. **filters** — move structured attributes to filters: gender, brand, category,
+   colour, size, price, rating. Only ever use a field listed above, and for a field
+   with valid values listed, use one of those values exactly.
+3. If a value the user asked for is not in the listed values, leave it in the query
+   instead of inventing a filter.
+4. Use numbers for numeric fields — 110, not "$110" and not "110".
+5. **Paired range fields (e.g. minPrice/maxPrice)** describe ONE item's range across
+   its variants — they are not two prices to choose between. minPrice is the cheapest
+   variant, maxPrice the dearest.
+   - "under $X" / "below $X" / "cheaper than $X" → minPrice <= X.
+     The shopper wants something buyable for under $X, so one qualifying variant is enough.
+     Filtering maxPrice <= X demands EVERY variant is under $X and returns almost nothing.
+   - "over $X" / "above $X" → maxPrice >= X.
+   - "between $X and $Y" → minPrice <= Y and maxPrice >= X.
+   - If only one of the pair is filterable, use that one rather than skipping the filter.
+6. If the phrase carries no structured constraint at all, return it as the query with
+   an empty filters array. Do not force a filter that was not asked for.`;
+
+    if (customInstructions) {
+        prompt += `\n\n## Additional instructions\n${customInstructions}`;
+    }
+
+    return prompt;
+}
+
+/** JSON schema for the model's structured response. */
+export const INTERPRETER_SCHEMA = {
+    type: 'object',
+    properties: {
+        query: {
+            type: 'string',
+            description: 'The descriptive search terms, with filter attributes removed',
+        },
+        filters: {
+            type: 'array',
+            description: 'Structured constraints extracted from the phrase',
+            items: {
+                type: 'object',
+                properties: {
+                    field: { type: 'string' },
+                    operator: { type: 'string', enum: [...INTERPRETER_OPERATORS] },
+                    value: {
+                        type: ['string', 'number', 'boolean'],
+                        description: 'Numbers for numeric fields, not strings',
+                    },
+                },
+                required: ['field', 'operator', 'value'],
+                additionalProperties: false,
+            },
+        },
+    },
+    required: ['query', 'filters'],
+    additionalProperties: false,
+} as const;
+
+// ============================================================================
+// PARSING
+// ============================================================================
+
+/**
+ * Parse the model's reply into an interpretation.
+ *
+ * Returns null on anything unexpected. The caller falls back to the raw query, so
+ * a bad interpretation degrades to ordinary search rather than breaking it.
+ */
+export function parseInterpretation(
+    content: string,
+    originalQuery: string,
+): ParsedInterpretation | null {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(content);
+    } catch {
+        return null;
+    }
+
+    if (!parsed || typeof parsed !== 'object') {
+        return null;
+    }
+
+    const raw = parsed as { query?: unknown; filters?: unknown };
+
+    // An empty query would match everything; the original is a safer floor.
+    const query = typeof raw.query === 'string' && raw.query.trim().length > 0
+        ? raw.query.trim()
+        : originalQuery;
+
+    const filters: InterpretedFilter[] = Array.isArray(raw.filters)
+        ? raw.filters.flatMap(entry => {
+            if (!entry || typeof entry !== 'object') return [];
+            const f = entry as { field?: unknown; operator?: unknown; value?: unknown };
+            if (typeof f.field !== 'string' || typeof f.operator !== 'string') return [];
+            if (!(INTERPRETER_OPERATORS as readonly string[]).includes(f.operator)) return [];
+            if (f.value === null || f.value === undefined) return [];
+            return [{ field: f.field, operator: f.operator, value: coerceValue(f.value) }];
+        })
+        : [];
+
+    return { query, filters };
+}
+
+/**
+ * Coerce a numeric-looking string to a number.
+ *
+ * Models return "110" or "$110" despite being told not to, and a string where a
+ * range query expects a number produces a filter that matches nothing.
+ */
+function coerceValue(value: unknown): unknown {
+    if (typeof value !== 'string') {
+        return value;
+    }
+    const stripped = value.replace(/[$€£,]/g, '').trim();
+    if (stripped !== '' && !Number.isNaN(Number(stripped))) {
+        return Number(stripped);
+    }
+    return value;
+}
+
+// ============================================================================
+// CONTEXT ASSEMBLY
+// ============================================================================
+
+/** Wrap field constraints in the shape param-validation expects. */
+export function toParameterContext(
+    constraints: Record<string, FieldConstraint>,
+): ParameterContext {
+    const count = Object.keys(constraints).length;
+    return {
+        fieldConstraints: constraints,
+        enriched: count > 0,
+        summary: `${count} filterable field(s)`,
+        durationMs: 0,
+    };
+}

--- a/backend/src/features/search-experience/query-interpreter.ts
+++ b/backend/src/features/search-experience/query-interpreter.ts
@@ -1,0 +1,373 @@
+// src/features/search-experience/query-interpreter.ts
+
+/**
+ * Query Interpreter
+ *
+ * Natural-language understanding for the search box: parses a typed phrase into a
+ * cleaned query plus structured filters before the search runs.
+ *
+ * The search path has no filter extraction of its own — filters arrive only from
+ * the request body, set by facet UI. So a shopper typing "men's t-shirts below
+ * $110" gets those words matched as text and no price filtering whatsoever. This
+ * closes that gap for experiences that opt in.
+ *
+ * Two properties are deliberate:
+ *
+ * - **Fail-open.** Any failure — model error, bad JSON, missing config — returns
+ *   the original query unchanged. A broken interpreter must degrade to ordinary
+ *   search, never break it.
+ * - **Cached with single-flight.** An LLM call on every keystroke would be slow and
+ *   expensive; CacheManager.getOrSet collapses concurrent identical queries into
+ *   one call.
+ */
+
+import 'server-only';
+
+import { CacheManager } from '@/shared/cache/cache-manager';
+import { createLogger } from '@/shared/logger/logger';
+import * as aiService from '@/features/ai-service';
+import * as searchIndexService from '@/features/search-index/search-index.service';
+import * as searchService from '@/features/search/search.service';
+import { validateFilters } from '@/features/pipeline/v2/param-validation';
+import type { FieldConstraint } from '@/features/pipeline/v2/parameter-context.types';
+import type { SearchIndexField } from '@/db/schema/search-index-fields.schema';
+import type { SearchExperienceQueryUnderstandingConfig } from '@/db/schema/search-experience.schema';
+import {
+    INTERPRETER_SCHEMA,
+    buildInterpreterPrompt,
+    parseInterpretation,
+    shouldInterpret,
+    toParameterContext,
+    type InterpretedFilter,
+} from './query-interpreter.core';
+
+const logger = createLogger('query-interpreter');
+
+/** Interpretations are per (index, query) and cheap to recompute; 10 minutes is plenty. */
+const cache = new CacheManager('query-interpreter', {
+    defaultTTL: 10 * 60 * 1000,
+    maxSize: 1000,
+});
+
+/** Field constraints change only when the index configuration does. */
+const constraintCache = new CacheManager('query-interpreter-fields', {
+    defaultTTL: 5 * 60 * 1000,
+    maxSize: 100,
+});
+
+/** How many distinct values to offer the model per text field. */
+const MAX_FACET_VALUES = 40;
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+export interface QueryInterpretation {
+    /** What the user typed */
+    originalQuery: string;
+    /** What should actually be searched for */
+    effectiveQuery: string;
+    /** Filters to apply alongside the query */
+    appliedFilters: InterpretedFilter[];
+    /** Filters the model proposed that the index could not honour */
+    droppedFilters: Array<{ field: string; reason: string }>;
+    /** False when interpretation was skipped or failed — effectiveQuery is then the original */
+    interpreted: boolean;
+    durationMs: number;
+}
+
+function passthrough(query: string, startedAt: number): QueryInterpretation {
+    return {
+        originalQuery: query,
+        effectiveQuery: query,
+        appliedFilters: [],
+        droppedFilters: [],
+        interpreted: false,
+        durationMs: Date.now() - startedAt,
+    };
+}
+
+// ============================================================================
+// FIELD CONSTRAINTS
+// ============================================================================
+
+/** Map an index field's declared type onto the coarse types the prompt uses. */
+function normalizeFieldType(fieldType: string): FieldConstraint['fieldType'] {
+    switch (fieldType) {
+        case 'number':
+            return 'number';
+        case 'boolean':
+            return 'boolean';
+        case 'date':
+        case 'datetime':
+            return 'date';
+        default:
+            return 'text';
+    }
+}
+
+/**
+ * Fetch the distinct values of a facetable text field.
+ *
+ * Grounding the model in real values is what turns "mens" into the index's actual
+ * "Men" — without it the filter matches nothing and looks broken.
+ */
+async function fetchFacetValues(searchIndexId: string, field: string): Promise<string[]> {
+    try {
+        const response = await searchService.searchById(searchIndexId, {
+            query: '*',
+            searchType: 'lexical',
+            pageSize: 1,
+            facets: [{
+                field,
+                type: 'terms',
+                size: MAX_FACET_VALUES,
+                orderBy: 'count',
+                orderDirection: 'desc',
+            }],
+        });
+        return response.facets?.find(f => f.field === field)?.buckets.map(b => String(b.key)) ?? [];
+    } catch (err) {
+        // A field whose values cannot be listed is still filterable; the model just
+        // loses the vocabulary hint for it.
+        logger.warn('Failed to fetch facet values', {
+            searchIndexId,
+            field,
+            error: err instanceof Error ? err.message : 'Unknown error',
+        });
+        return [];
+    }
+}
+
+/**
+ * Build the filterable-field map for an index.
+ *
+ * `isIndexed` is what makes a field filterable at query time — that is the check
+ * the filter builder itself applies — while `isFacetable` decides whether its
+ * values can be enumerated for the prompt.
+ */
+async function loadFieldConstraints(
+    searchIndexId: string,
+): Promise<Record<string, FieldConstraint>> {
+    const cached = await constraintCache.get<Record<string, FieldConstraint>>(searchIndexId);
+    if (cached) {
+        return cached;
+    }
+
+    const index = await searchIndexService.getSearchIndexById(searchIndexId);
+    if (!index) {
+        return {};
+    }
+
+    const filterable = index.fields.filter(
+        (f: SearchIndexField) => f.isIndexed && f.fieldName !== 'content_embedding',
+    );
+
+    const constraints: Record<string, FieldConstraint> = {};
+
+    await Promise.all(filterable.map(async (field: SearchIndexField) => {
+        const fieldType = normalizeFieldType(field.fieldType);
+        const canEnumerate = field.isFacetable && fieldType === 'text';
+
+        constraints[field.fieldName] = {
+            fieldName: field.fieldName,
+            fieldType,
+            isFilterable: true,
+            isFacetable: field.isFacetable,
+            validValues: canEnumerate ? await fetchFacetValues(searchIndexId, field.fieldName) : [],
+        };
+    }));
+
+    await constraintCache.set(searchIndexId, constraints);
+    return constraints;
+}
+
+/** Drop cached field constraints for an index after its configuration changes. */
+export async function invalidateQueryInterpreterCache(searchIndexId: string): Promise<void> {
+    await constraintCache.delete(searchIndexId);
+}
+
+/**
+ * Interpret a request's query and fold the result into its filters.
+ *
+ * Shared by both search entry points — the public token route and the slug route —
+ * so a phrase behaves identically wherever it is typed.
+ *
+ * Client-supplied filters win: those come from facet UI the user clicked
+ * deliberately, and an inferred filter must never override an explicit choice. An
+ * interpreted filter is only added for a field the request does not already
+ * constrain.
+ */
+export async function applyQueryInterpretation(options: {
+    query: string;
+    clientFilters: Array<{ field: string; operator: string; value: unknown }> | undefined;
+    searchIndexId: string | undefined;
+    config?: SearchExperienceQueryUnderstandingConfig;
+    providerId?: string | null;
+    modelId?: number | null;
+    experienceId?: string;
+}): Promise<{
+    query: string;
+    filters: Array<{ field: string; operator: string; value: unknown }> | undefined;
+    interpretation?: QueryInterpretation;
+}> {
+    const { query, clientFilters, searchIndexId } = options;
+
+    if (!searchIndexId || !options.config?.enabled) {
+        return { query, filters: clientFilters };
+    }
+
+    const interpretation = await interpretQuery({
+        query,
+        searchIndexId,
+        config: options.config,
+        providerId: options.providerId,
+        modelId: options.modelId,
+        experienceId: options.experienceId,
+    });
+
+    if (!interpretation.interpreted) {
+        return { query, filters: clientFilters, interpretation };
+    }
+
+    const clientFields = new Set((clientFilters ?? []).map(f => f.field));
+    const additions = interpretation.appliedFilters.filter(f => !clientFields.has(f.field));
+    const merged = [...(clientFilters ?? []), ...additions];
+
+    return {
+        query: interpretation.effectiveQuery,
+        filters: merged.length > 0 ? merged : undefined,
+        interpretation: { ...interpretation, appliedFilters: additions },
+    };
+}
+
+// ============================================================================
+// INTERPRETATION
+// ============================================================================
+
+export interface InterpretQueryOptions {
+    query: string;
+    searchIndexId: string;
+    config?: SearchExperienceQueryUnderstandingConfig;
+    /** Provider/model from the experience's aiConfig; null means system default. */
+    providerId?: string | null;
+    modelId?: number | null;
+    /** For per-experience telemetry detail */
+    experienceId?: string;
+}
+
+/**
+ * Interpret a search phrase into a query plus filters.
+ *
+ * Never throws: every failure path returns the original query untouched.
+ */
+export async function interpretQuery(
+    options: InterpretQueryOptions,
+): Promise<QueryInterpretation> {
+    const startedAt = Date.now();
+    const { query, searchIndexId, config } = options;
+
+    if (!config?.enabled) {
+        return passthrough(query, startedAt);
+    }
+    if (!shouldInterpret(query, config.minWords ?? 3)) {
+        return passthrough(query, startedAt);
+    }
+
+    try {
+        const constraints = await loadFieldConstraints(searchIndexId);
+        if (Object.keys(constraints).length === 0) {
+            return passthrough(query, startedAt);
+        }
+
+        // Key on the index too: the same phrase means different things against
+        // different field sets.
+        const cacheKey = `${searchIndexId}:${query.trim().toLowerCase()}`;
+
+        const result = await cache.getOrSet<QueryInterpretation | null>(cacheKey, async () => {
+            const systemPrompt = buildInterpreterPrompt(constraints, config.customInstructions);
+
+            const completion = await aiService.chat(
+                [
+                    { role: 'system', content: systemPrompt },
+                    { role: 'user', content: query },
+                ],
+                {
+                    providerId: options.providerId ?? undefined,
+                    modelId: options.modelId ?? undefined,
+                    temperature: 0,
+                    maxTokens: 500,
+                    feature: 'search_query_understanding',
+                    experienceId: options.experienceId,
+                    responseFormat: {
+                        type: 'json_schema',
+                        json_schema: {
+                            name: 'query_interpretation',
+                            strict: true,
+                            schema: INTERPRETER_SCHEMA as unknown as {
+                                type: 'object';
+                                properties: Record<string, unknown>;
+                                required?: string[];
+                                additionalProperties?: boolean;
+                            },
+                        },
+                    },
+                },
+            );
+
+            // Content is a string for ordinary completions, but the type allows
+            // structured blocks; only text can carry the JSON we asked for.
+            const rawContent = completion.message?.content;
+            const text = typeof rawContent === 'string'
+                ? rawContent
+                : (rawContent ?? [])
+                    .map(block => (typeof block === 'object' && block !== null && 'text' in block
+                        ? String((block as { text?: unknown }).text ?? '')
+                        : ''))
+                    .join('');
+
+            const parsed = parseInterpretation(text, query);
+            if (!parsed) {
+                return null;
+            }
+
+            // Same validation the agentic path uses: drops unknown or non-filterable
+            // fields and canonicalises text values against the index's real ones.
+            const validation = validateFilters(parsed.filters, toParameterContext(constraints));
+
+            return {
+                originalQuery: query,
+                effectiveQuery: parsed.query,
+                appliedFilters: validation.filters,
+                droppedFilters: validation.droppedFilters.map(d => ({
+                    field: d.field,
+                    reason: d.reason,
+                })),
+                interpreted: true,
+                durationMs: 0,
+            };
+        });
+
+        if (!result) {
+            return passthrough(query, startedAt);
+        }
+
+        logger.info('Query interpreted', {
+            searchIndexId,
+            originalQuery: query,
+            effectiveQuery: result.effectiveQuery,
+            filters: result.appliedFilters.map(f => `${f.field}${f.operator}${String(f.value)}`),
+            dropped: result.droppedFilters.length,
+            durationMs: Date.now() - startedAt,
+        });
+
+        return { ...result, durationMs: Date.now() - startedAt };
+    } catch (err) {
+        // Fail open — a search that returns loose results beats one that errors.
+        logger.warn('Query interpretation failed; searching with the raw query', {
+            searchIndexId,
+            error: err instanceof Error ? err.message : 'Unknown error',
+        });
+        return passthrough(query, startedAt);
+    }
+}

--- a/backend/src/features/search-experience/query-interpreter.ts
+++ b/backend/src/features/search-experience/query-interpreter.ts
@@ -280,10 +280,9 @@ export async function interpretQuery(
             return passthrough(query, startedAt);
         }
 
-        // Key on the index too: the same phrase means different things against
-        // different field sets.
-        const cacheKey = `${searchIndexId}:${query.trim().toLowerCase()}`;
-
+        // Key on the index + experience/model: the same phrase can be interpreted differently
+        // depending on provider/model and per-experience instructions.
+        const cacheKey = `${searchIndexId}:${options.experienceId ?? 'no-exp'}:${options.providerId ?? 'default'}:${options.modelId ?? 'default'}:${query.trim().toLowerCase()}`;
         const result = await cache.getOrSet<QueryInterpretation | null>(cacheKey, async () => {
             const systemPrompt = buildInterpreterPrompt(constraints, config.customInstructions);
 

--- a/backend/src/features/search-experience/search-experience.api.handlers.ts
+++ b/backend/src/features/search-experience/search-experience.api.handlers.ts
@@ -23,6 +23,7 @@ import {
   handleCorsPreflight,
 } from './access-token.middleware';
 import { publicSearchRequestSchema, autocompleteRequestSchema } from './search-experience.schemas';
+import { applyQueryInterpretation } from './query-interpreter';
 import type {
   SearchExperienceWithIndexes,
   PublicSearchRequest,
@@ -179,8 +180,19 @@ async function buildSearchRequest(
 ): Promise<SearchRequest> {
   const searchConfig = experience.searchConfig;
 
-  // Cast filters to the expected types (they come validated from schema)
-  const filters = publicRequest.filters as SearchRequest['filters'];
+  // Natural-language understanding: turn "men's t-shirts below $110" into a clean
+  // query plus real filters before searching. No-op unless the experience opts in.
+  const interpreted = await applyQueryInterpretation({
+    query: publicRequest.query,
+    clientFilters: publicRequest.filters as Array<{ field: string; operator: string; value: unknown }> | undefined,
+    searchIndexId: indexes[0]?.searchIndex?.id,
+    config: experience.aiConfig?.queryUnderstanding,
+    providerId: experience.aiConfig?.providerId,
+    modelId: experience.aiConfig?.modelId,
+    experienceId: experience.id,
+  });
+
+  const filters = interpreted.filters as SearchRequest['filters'];
 
   // Handle facets: either use explicit facets from request or auto-generate from facetable fields
   let facets: SearchRequest['facets'] | undefined;
@@ -198,7 +210,7 @@ async function buildSearchRequest(
   }
 
   return {
-    query: publicRequest.query,
+    query: interpreted.query,
     searchType: publicRequest.searchType ?? 'auto',
     filters,
     facets,

--- a/backend/src/features/search-experience/search-experience.schemas.ts
+++ b/backend/src/features/search-experience/search-experience.schemas.ts
@@ -102,11 +102,18 @@ export const aiSummaryConfigSchema = z.object({
   maxTokens: z.number().int().min(50).max(4000).optional(),
 });
 
+export const queryUnderstandingConfigSchema = z.object({
+  enabled: z.boolean().default(false),
+  minWords: z.number().int().min(1).max(20).default(3),
+  customInstructions: z.string().max(5000).optional(),
+});
+
 export const aiConfigSchema = z.object({
   enabled: z.boolean().default(DEFAULT_AI_CONFIG.enabled),
   providerId: z.string().uuid().nullable().default(null),
   modelId: z.number().int().positive().nullable().default(null),
   summary: aiSummaryConfigSchema.default(DEFAULT_AI_CONFIG.summary),
+  queryUnderstanding: queryUnderstandingConfigSchema.optional(),
 });
 
 // ============================================================================

--- a/backend/src/features/search-experience/search-experience.service.ts
+++ b/backend/src/features/search-experience/search-experience.service.ts
@@ -35,6 +35,7 @@ import type {
 import {
   DEFAULT_SEARCH_CONFIG,
   DEFAULT_AI_CONFIG,
+  DEFAULT_QUERY_UNDERSTANDING_CONFIG,
   DEFAULT_TOOLS_CONFIG,
 } from './search-experience.types';
 import { setExperienceTelemetryOverride } from '@/features/telemetry';
@@ -154,10 +155,16 @@ export async function createSearchExperience(
     autocomplete: { ...DEFAULT_SEARCH_CONFIG.autocomplete, ...validated.searchConfig?.autocomplete },
     hybridConfig, // Always include hybridConfig with resolved values
   };
+  // Each nested block is merged explicitly: a spread of aiConfig alone would
+  // replace a sub-object wholesale, silently dropping any field the caller omitted.
   const aiConfig = {
     ...DEFAULT_AI_CONFIG,
     ...validated.aiConfig,
     summary: { ...DEFAULT_AI_CONFIG.summary, ...validated.aiConfig?.summary },
+    queryUnderstanding: {
+      ...DEFAULT_QUERY_UNDERSTANDING_CONFIG,
+      ...validated.aiConfig?.queryUnderstanding,
+    },
   };
   const toolsConfig = { ...DEFAULT_TOOLS_CONFIG, ...validated.toolsConfig };
 
@@ -396,6 +403,11 @@ export async function updateSearchExperience(
       summary: {
         ...existing.aiConfig.summary,
         ...validated.aiConfig.summary,
+      },
+      queryUnderstanding: {
+        ...DEFAULT_QUERY_UNDERSTANDING_CONFIG,
+        ...existing.aiConfig.queryUnderstanding,
+        ...validated.aiConfig.queryUnderstanding,
       },
     };
   }

--- a/backend/src/features/search-experience/search-experience.types.ts
+++ b/backend/src/features/search-experience/search-experience.types.ts
@@ -453,11 +453,18 @@ export const DEFAULT_AI_SUMMARY_CONFIG = {
   maxTokens: 500,
 };
 
+/** Off by default: it adds an LLM call to every search. */
+export const DEFAULT_QUERY_UNDERSTANDING_CONFIG = {
+  enabled: false,
+  minWords: 3,
+};
+
 export const DEFAULT_AI_CONFIG: SearchExperienceAIConfig = {
   enabled: true,
   providerId: null,
   modelId: null,
   summary: DEFAULT_AI_SUMMARY_CONFIG,
+  queryUnderstanding: DEFAULT_QUERY_UNDERSTANDING_CONFIG,
 };
 
 export const DEFAULT_TOOLS_CONFIG: SearchExperienceToolsConfig = {

--- a/backend/src/features/search-index/search-index.service.ts
+++ b/backend/src/features/search-index/search-index.service.ts
@@ -13,6 +13,11 @@ import * as repository from './search-index.repository';
 import type { SearchIndexReference } from './search-index.repository';
 import * as fieldsService from './search-index-fields.service';
 import { invalidateSearchExperienceCacheBySearchIndex } from '@/features/search-experience';
+import {
+    EMBEDDING_FIELD_NAME,
+    generateDocumentEmbeddings,
+    getEmbeddingConfig,
+} from '@/features/document-indexing/document-indexer.service';
 import type {
     // DTOs
     CreateSearchIndexDTO,
@@ -956,12 +961,16 @@ export async function triggerReindex(
             // this, a field deleted from the configuration comes straight back:
             // the new mapping omits it, but Elasticsearch's dynamic mapping
             // re-adds it from the document body, so the rebuild would silently
-            // fail to purge anything. The embedding field is kept because it is
-            // stored but not a configured field.
-            const allowedFields = new Set<string>([
-                ...fields.map(f => f.fieldName),
-                ...(embeddingConfig ? [embeddingConfig.fieldName] : []),
-            ]);
+            // fail to purge anything.
+            //
+            // The embedding field is deliberately NOT carried over. It is not
+            // present in _source at all, so there would be nothing to copy — a
+            // rebuild that relied on copying produced an index with zero vectors
+            // and reported success. Vectors are regenerated below instead, which
+            // is also the correct semantics: a reindex is exactly when the vector
+            // source configuration may have changed, so an old vector would
+            // describe the wrong text.
+            const allowedFields = new Set<string>(fields.map(f => f.fieldName));
 
             const bulkDocs = documents.map(doc => {
                 const source: Record<string, unknown> = {};
@@ -976,7 +985,9 @@ export async function triggerReindex(
             const droppedFieldNames = [
                 ...new Set(
                     documents.flatMap(doc =>
-                        Object.keys(doc._source).filter(key => !allowedFields.has(key))
+                        Object.keys(doc._source).filter(
+                            key => !allowedFields.has(key) && key !== EMBEDDING_FIELD_NAME
+                        )
                     )
                 ),
             ];
@@ -985,6 +996,52 @@ export async function triggerReindex(
                     indexName,
                     droppedFields: droppedFieldNames,
                 });
+            }
+
+            // Step 5b: Rebuild embeddings before writing.
+            //
+            // Failing here aborts the whole reindex. Writing the documents anyway
+            // would leave a semantic/hybrid index whose vector half is silently
+            // dead — every document unreachable by kNN — while the operation
+            // reported success. An index that still has its old mapping is far
+            // easier to recover from than one that looks healthy and is not.
+            const reindexEmbeddingConfig = getEmbeddingConfig(searchIndex);
+
+            if (reindexEmbeddingConfig.enabled) {
+                const vectorSourceFields = await fieldsService.getVectorSourceFields(searchIndexId);
+
+                if (vectorSourceFields.length === 0) {
+                    logger.warn('Embeddings enabled but no vector source fields configured', {
+                        indexName,
+                    });
+                } else {
+                    const embeddingResult = await generateDocumentEmbeddings(
+                        bulkDocs,
+                        vectorSourceFields,
+                        reindexEmbeddingConfig,
+                        `reindex-${searchIndexId}`
+                    );
+
+                    if (embeddingResult.stats.failed > 0) {
+                        throw new Error(
+                            `Embedding generation failed for ${embeddingResult.stats.failed} of `
+                            + `${bulkDocs.length} documents: `
+                            + `${embeddingResult.errors[0]?.error ?? 'unknown error'}`
+                        );
+                    }
+
+                    embeddingResult.embeddings.forEach((vector, docIndex) => {
+                        if (vector) {
+                            bulkDocs[docIndex][EMBEDDING_FIELD_NAME] = vector;
+                        }
+                    });
+
+                    logger.info('Embeddings regenerated during reindex', {
+                        indexName,
+                        generated: embeddingResult.stats.generated,
+                        skipped: embeddingResult.stats.skipped,
+                    });
+                }
             }
 
             const bulkResult = await provider.bulkIndex(indexName, bulkDocs, { refresh: true });

--- a/backend/src/features/search-index/search-index.service.ts
+++ b/backend/src/features/search-index/search-index.service.ts
@@ -848,6 +848,112 @@ export async function getIndexStats(
  * 3. Recreate with updated mappings (including autocomplete analyzers)
  * 4. Re-index all documents
  */
+/**
+ * Build the document bodies a reindex will write back, embeddings included.
+ *
+ * Kept separate from triggerReindex, and called BEFORE the index is deleted, so
+ * that every fallible step — field filtering, and above all the external
+ * embedding call — happens while the existing index is still intact. Previously
+ * this ran after the delete, so a transient AI-provider error threw with the only
+ * copy of the documents sitting in a discarded in-memory array, permanently
+ * emptying the index.
+ *
+ * Throws on embedding failure. The caller has not destroyed anything yet, so the
+ * reindex simply aborts and the index keeps its old mapping and its documents.
+ */
+async function prepareReindexDocuments(input: {
+    documents: Array<{ _id: string; _source: Record<string, unknown> }>;
+    fields: Awaited<ReturnType<typeof fieldsService.getFieldsBySearchIndexId>>;
+    searchIndex: Parameters<typeof getEmbeddingConfig>[0];
+    searchIndexId: string;
+    indexName: string;
+}): Promise<Array<{ _id: string; [key: string]: unknown }>> {
+    const { documents, fields, searchIndex, searchIndexId, indexName } = input;
+
+    if (documents.length === 0) {
+        return [];
+    }
+
+    // Bodies are filtered to the fields that are still configured. Without this, a
+    // field deleted from the configuration comes straight back: the new mapping
+    // omits it, but Elasticsearch's dynamic mapping re-adds it from the document
+    // body, so the rebuild would silently fail to purge anything.
+    //
+    // The embedding field is deliberately NOT carried over. It is not present in
+    // _source at all, so there would be nothing to copy — a rebuild that relied on
+    // copying produced an index with zero vectors and reported success. Vectors are
+    // regenerated below instead, which is also the correct semantics: a reindex is
+    // exactly when the vector source configuration may have changed, so an old
+    // vector would describe the wrong text.
+    const allowedFields = new Set<string>(fields.map(f => f.fieldName));
+
+    const bulkDocs = documents.map(doc => {
+        const source: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(doc._source)) {
+            if (allowedFields.has(key)) {
+                source[key] = value;
+            }
+        }
+        return { _id: doc._id, ...source };
+    });
+
+    const droppedFieldNames = [
+        ...new Set(
+            documents.flatMap(doc =>
+                Object.keys(doc._source).filter(
+                    key => !allowedFields.has(key) && key !== EMBEDDING_FIELD_NAME
+                )
+            )
+        ),
+    ];
+    if (droppedFieldNames.length > 0) {
+        logger.info('Dropping unconfigured fields during reindex', {
+            indexName,
+            droppedFields: droppedFieldNames,
+        });
+    }
+
+    const reindexEmbeddingConfig = getEmbeddingConfig(searchIndex);
+    if (!reindexEmbeddingConfig.enabled) {
+        return bulkDocs;
+    }
+
+    const vectorSourceFields = await fieldsService.getVectorSourceFields(searchIndexId);
+    if (vectorSourceFields.length === 0) {
+        logger.warn('Embeddings enabled but no vector source fields configured', { indexName });
+        return bulkDocs;
+    }
+
+    const embeddingResult = await generateDocumentEmbeddings(
+        bulkDocs,
+        vectorSourceFields,
+        reindexEmbeddingConfig,
+        `reindex-${searchIndexId}`
+    );
+
+    if (embeddingResult.stats.failed > 0) {
+        throw new Error(
+            `Embedding generation failed for ${embeddingResult.stats.failed} of `
+            + `${bulkDocs.length} documents: `
+            + `${embeddingResult.errors[0]?.error ?? 'unknown error'}`
+        );
+    }
+
+    embeddingResult.embeddings.forEach((vector, docIndex) => {
+        if (vector) {
+            bulkDocs[docIndex][EMBEDDING_FIELD_NAME] = vector;
+        }
+    });
+
+    logger.info('Embeddings regenerated during reindex', {
+        indexName,
+        generated: embeddingResult.stats.generated,
+        skipped: embeddingResult.stats.skipped,
+    });
+
+    return bulkDocs;
+}
+
 export async function triggerReindex(
     searchIndexId: string,
     userId: string
@@ -893,18 +999,11 @@ export async function triggerReindex(
                 });
             }
 
-            // Step 2: Delete the existing index
-            logger.info('Deleting existing index', { indexName });
-            const deleteResult = await provider.deleteIndex(indexName);
-
-            if (!deleteResult.success) {
-                throw new Error(`Failed to delete index: ${deleteResult.error}`);
-            }
         } else {
             logger.info('Index does not exist, will create fresh', { indexName });
         }
 
-        // Step 3: Get field configurations and build provider-native index settings
+        // Step 2: Get field configurations and build provider-native index settings
         const fields = await fieldsService.getFieldsBySearchIndexId(searchIndexId);
 
         // Get embedding config from the DB record (not from documents, since vector
@@ -940,7 +1039,33 @@ export async function triggerReindex(
             provider: searchIndex.searchProvider,
         });
 
-        // Step 4: Create the new index with provider-built settings
+        // Step 3: Prepare the documents to write back — INCLUDING their embeddings.
+        //
+        // Everything that can fail happens here, while the existing index is still
+        // intact. Embedding generation calls an external AI provider, so it is the
+        // most likely step to fail; doing it after the delete meant a transient
+        // provider error destroyed the index, because the only copy of the
+        // documents was the in-memory array discarded with the thrown error.
+        const preparedDocs = await prepareReindexDocuments({
+            documents,
+            fields,
+            searchIndex,
+            searchIndexId,
+            indexName,
+        });
+
+        // Step 4: Delete the existing index — the first destructive step, and
+        // deliberately the last thing that happens before recreating it.
+        if (indexExistsNow) {
+            logger.info('Deleting existing index', { indexName });
+            const deleteResult = await provider.deleteIndex(indexName);
+
+            if (!deleteResult.success) {
+                throw new Error(`Failed to delete index: ${deleteResult.error}`);
+            }
+        }
+
+        // Step 5: Create the new index with provider-built settings
         logger.info('Creating index with new mappings', { indexName });
         const createResult = await provider.createIndex(indexName, indexConfig);
 
@@ -948,101 +1073,14 @@ export async function triggerReindex(
             throw new Error(`Failed to create index: ${createResult.error}`);
         }
 
-        // Step 5: Re-index all documents
-        if (documents.length > 0) {
+        // Step 6: Write the prepared documents back
+        if (preparedDocs.length > 0) {
             logger.info('Re-indexing documents', {
                 indexName,
-                documentCount: documents.length,
+                documentCount: preparedDocs.length,
             });
 
-            // Convert scroll documents to bulk format, preserving IDs.
-            //
-            // Bodies are filtered to the fields that are still configured. Without
-            // this, a field deleted from the configuration comes straight back:
-            // the new mapping omits it, but Elasticsearch's dynamic mapping
-            // re-adds it from the document body, so the rebuild would silently
-            // fail to purge anything.
-            //
-            // The embedding field is deliberately NOT carried over. It is not
-            // present in _source at all, so there would be nothing to copy — a
-            // rebuild that relied on copying produced an index with zero vectors
-            // and reported success. Vectors are regenerated below instead, which
-            // is also the correct semantics: a reindex is exactly when the vector
-            // source configuration may have changed, so an old vector would
-            // describe the wrong text.
-            const allowedFields = new Set<string>(fields.map(f => f.fieldName));
-
-            const bulkDocs = documents.map(doc => {
-                const source: Record<string, unknown> = {};
-                for (const [key, value] of Object.entries(doc._source)) {
-                    if (allowedFields.has(key)) {
-                        source[key] = value;
-                    }
-                }
-                return { _id: doc._id, ...source };
-            });
-
-            const droppedFieldNames = [
-                ...new Set(
-                    documents.flatMap(doc =>
-                        Object.keys(doc._source).filter(
-                            key => !allowedFields.has(key) && key !== EMBEDDING_FIELD_NAME
-                        )
-                    )
-                ),
-            ];
-            if (droppedFieldNames.length > 0) {
-                logger.info('Dropping unconfigured fields during reindex', {
-                    indexName,
-                    droppedFields: droppedFieldNames,
-                });
-            }
-
-            // Step 5b: Rebuild embeddings before writing.
-            //
-            // Failing here aborts the whole reindex. Writing the documents anyway
-            // would leave a semantic/hybrid index whose vector half is silently
-            // dead — every document unreachable by kNN — while the operation
-            // reported success. An index that still has its old mapping is far
-            // easier to recover from than one that looks healthy and is not.
-            const reindexEmbeddingConfig = getEmbeddingConfig(searchIndex);
-
-            if (reindexEmbeddingConfig.enabled) {
-                const vectorSourceFields = await fieldsService.getVectorSourceFields(searchIndexId);
-
-                if (vectorSourceFields.length === 0) {
-                    logger.warn('Embeddings enabled but no vector source fields configured', {
-                        indexName,
-                    });
-                } else {
-                    const embeddingResult = await generateDocumentEmbeddings(
-                        bulkDocs,
-                        vectorSourceFields,
-                        reindexEmbeddingConfig,
-                        `reindex-${searchIndexId}`
-                    );
-
-                    if (embeddingResult.stats.failed > 0) {
-                        throw new Error(
-                            `Embedding generation failed for ${embeddingResult.stats.failed} of `
-                            + `${bulkDocs.length} documents: `
-                            + `${embeddingResult.errors[0]?.error ?? 'unknown error'}`
-                        );
-                    }
-
-                    embeddingResult.embeddings.forEach((vector, docIndex) => {
-                        if (vector) {
-                            bulkDocs[docIndex][EMBEDDING_FIELD_NAME] = vector;
-                        }
-                    });
-
-                    logger.info('Embeddings regenerated during reindex', {
-                        indexName,
-                        generated: embeddingResult.stats.generated,
-                        skipped: embeddingResult.stats.skipped,
-                    });
-                }
-            }
+            const bulkDocs = preparedDocs;
 
             const bulkResult = await provider.bulkIndex(indexName, bulkDocs, { refresh: true });
 

--- a/backend/src/features/search/search-context.builder.ts
+++ b/backend/src/features/search/search-context.builder.ts
@@ -166,11 +166,47 @@ function buildDefaultResponseFields(fields: SearchIndexField[]): string[] {
 }
 
 /**
+ * Build the list of fields worth showing when browsing an index's documents.
+ *
+ * Same retrievability predicate as buildDefaultResponseFields, with two
+ * deliberate differences:
+ *
+ * - Generated timestamps are admitted. They are useless noise in a search
+ *   response, but "when did this document last change" is one of the most
+ *   useful columns an admin browse table can have.
+ * - Field rows are returned rather than names, because the caller ranks
+ *   candidates by fieldType/isFacetable to decide which ones make good columns.
+ *
+ * Timestamps are opt-in rather than the default because a field row existing in
+ * Postgres does not prove the field exists in the provider mapping — see the
+ * caller's requiresReindex guard.
+ */
+export function buildBrowsableFields(
+    fields: SearchIndexField[],
+    options: { includeGeneratedTimestamps?: boolean } = {}
+): SearchIndexField[] {
+    const allowGeneratedTimestamps = options.includeGeneratedTimestamps ?? false;
+    return fields.filter(field =>
+        field.includeInResponse
+        && field.isIndexed
+        && hasDataAvailable(field)
+        && !isEmptySystemField(field, { allowGeneratedTimestamps })
+    );
+}
+
+/**
  * Check if a system field is empty/unconfigured and shouldn't be requested.
  * Also excludes auto-generated system timestamp fields (createdAt, updatedAt)
  * which are not useful in search responses and may not exist in the provider index.
+ *
+ * `allowGeneratedTimestamps` keeps the timestamp fields in — used only by
+ * document browse (see buildBrowsableFields). It defaults to false so search
+ * behaviour is unchanged.
  */
-function isEmptySystemField(field: SearchIndexField): boolean {
+function isEmptySystemField(
+    field: SearchIndexField,
+    options: { allowGeneratedTimestamps?: boolean } = {}
+): boolean {
     if (!field.isSystemField) return false;
     const config = field.transformConfig as { mode?: string; collectFields?: string[]; generator?: string } | null;
     // additionalData/customFields with mode='none' or mode='collect' with empty collectFields
@@ -181,7 +217,7 @@ function isEmptySystemField(field: SearchIndexField): boolean {
     // Auto-generated timestamp fields (createdAt, updatedAt) — these exist in the DB
     // but are not useful in search responses and may not be retrievable in all providers
     if (config?.mode === 'generated' && config.generator === 'timestamp') {
-        return true;
+        return !options.allowGeneratedTimestamps;
     }
     return false;
 }

--- a/backend/src/features/tools/tools.service.ts
+++ b/backend/src/features/tools/tools.service.ts
@@ -158,6 +158,63 @@ export async function createToolsForDataSource(
   return createdTools;
 }
 
+/**
+ * Rebuild the generated schemas of a data source's scaffolded tools.
+ *
+ * A tool's inputSchema is generated once, at scaffold time — including the
+ * `filters[].field` enum, which is the only list of filterable fields the model
+ * ever sees. Making a field filterable afterwards therefore had no effect: the
+ * field never entered the enum, so the model could not filter on it and the user
+ * saw the filter silently ignored.
+ *
+ * Only `isSystem` tools are touched. A hand-created or hand-edited tool has an
+ * aiDescription someone wrote deliberately, and regenerating would discard it.
+ *
+ * Best-effort by design: this runs as a side effect of a field-config change,
+ * and a stale enum must not fail that change.
+ *
+ * @returns how many tools were updated
+ */
+export async function regenerateSchemasForDataSource(
+  dataSourceId: string,
+  dataSourceName: string,
+  dataSourceType: DataSourceType,
+  schema?: DataSourceSchema | null,
+): Promise<number> {
+  const existingTools = await repository.getToolsByDataSourceId(dataSourceId);
+  let updated = 0;
+
+  for (const tool of existingTools) {
+    if (!tool.isSystem || !tool.operation) {
+      continue;
+    }
+
+    try {
+      const { aiDescription, inputSchema } = generateToolDescription(
+        dataSourceName,
+        dataSourceType,
+        tool.operation as DataSourceOperation,
+        schema,
+      );
+      await repository.updateTool(tool.id, { aiDescription, inputSchema });
+      updated++;
+    } catch (err) {
+      logger.warn('Failed to regenerate tool schema', {
+        toolId: tool.id,
+        slug: tool.slug,
+        error: err instanceof Error ? err.message : 'Unknown error',
+      });
+    }
+  }
+
+  if (updated > 0) {
+    await clearListCache();
+    logger.info('Regenerated tool schemas after schema change', { dataSourceId, updated });
+  }
+
+  return updated;
+}
+
 // ============================================================================
 // DESCRIPTION GENERATION (for UI pre-fill)
 // ============================================================================

--- a/backend/src/shared/utils/field-roles.ts
+++ b/backend/src/shared/utils/field-roles.ts
@@ -1,0 +1,54 @@
+// src/shared/utils/field-roles.ts
+
+/**
+ * Field Role Inference
+ *
+ * Guesses the semantic role of a field from its name alone — "what is this field
+ * for?" rather than "what type does it hold?". Purely name-based on purpose: it
+ * runs against indexes that carry no role configuration at all, which is most of
+ * them. A null result means "no idea", never "no role".
+ *
+ * Two consumers, deliberately sharing one vocabulary:
+ * - data source schema discovery, which persists the role on DataSourceField and
+ *   feeds it into generated tool descriptions
+ * - document browse column selection, which uses it to find a title field and to
+ *   rank the remaining candidates
+ */
+
+/**
+ * Semantic role of a field.
+ *
+ * Kept structurally identical to DataSourceField['role'] (minus the null, which
+ * callers add themselves) so the two stay assignable without a cast.
+ */
+export type FieldRole =
+    | 'title'
+    | 'description'
+    | 'content'
+    | 'price'
+    | 'image'
+    | 'category'
+    | 'id'
+    | 'url'
+    | 'date';
+
+/**
+ * Infer a field's semantic role from its name.
+ *
+ * Exact matches are checked before the substring rule at the end, so a field
+ * named `updated_date` resolves to 'date' while `title` never falls through to
+ * it. Returns null when the name carries no recognisable signal.
+ */
+export function inferFieldRole(fieldName: string): FieldRole | null {
+    const name = fieldName.toLowerCase();
+    if (name === 'title' || name === 'name' || name === 'product_name') return 'title';
+    if (name === 'description' || name === 'summary') return 'description';
+    if (name === 'content' || name === 'body' || name === 'text') return 'content';
+    if (name === 'price' || name === 'cost') return 'price';
+    if (name === 'image' || name === 'image_url' || name === 'thumbnail') return 'image';
+    if (name === 'category' || name === 'categories') return 'category';
+    if (name === 'url' || name === 'link' || name === 'href') return 'url';
+    if (name === 'id' || name === 'unique_id') return 'id';
+    if (name.includes('date') || name.includes('created') || name.includes('updated')) return 'date';
+    return null;
+}

--- a/backend/src/shared/utils/index.ts
+++ b/backend/src/shared/utils/index.ts
@@ -19,6 +19,8 @@ export { mapFieldTypeToES } from './elasticsearch-field-mapping';
 export { inferFieldRole } from './field-roles';
 export type { FieldRole } from './field-roles';
 
+export { safeUrl, safeMailto } from './safe-url';
+
 // Add other utilities as you create them:
 // export * from './date';
 // export * from './validation';

--- a/backend/src/shared/utils/index.ts
+++ b/backend/src/shared/utils/index.ts
@@ -16,6 +16,9 @@ export {
 
 export { mapFieldTypeToES } from './elasticsearch-field-mapping';
 
+export { inferFieldRole } from './field-roles';
+export type { FieldRole } from './field-roles';
+
 // Add other utilities as you create them:
 // export * from './date';
 // export * from './validation';

--- a/backend/src/shared/utils/safe-url.test.ts
+++ b/backend/src/shared/utils/safe-url.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+
+import { safeMailto, safeUrl } from './safe-url';
+
+// ============================================================================
+// safeUrl
+// ============================================================================
+
+describe('safeUrl — schemes that must be blocked', () => {
+    it('rejects javascript:', () => {
+        // Would execute in the admin's authenticated session if rendered as an href.
+        expect(safeUrl('javascript:alert(1)')).toBeNull();
+        expect(safeUrl('JavaScript:alert(1)')).toBeNull();
+    });
+
+    it('rejects data:', () => {
+        expect(safeUrl('data:text/html,<script>alert(1)</script>')).toBeNull();
+    });
+
+    it('rejects other non-web schemes', () => {
+        expect(safeUrl('file:///etc/passwd')).toBeNull();
+        expect(safeUrl('vbscript:msgbox(1)')).toBeNull();
+        expect(safeUrl('ftp://example.com/x')).toBeNull();
+    });
+
+    it('rejects a protocol-relative URL', () => {
+        // Adopts the page's scheme but points at another origin — it must not be
+        // mistaken for a same-origin relative path.
+        expect(safeUrl('//evil.com/x.jpg')).toBeNull();
+    });
+
+    it('rejects leading whitespace used to disguise a scheme', () => {
+        expect(safeUrl('  javascript:alert(1)')).toBeNull();
+    });
+});
+
+describe('safeUrl — values that must keep working', () => {
+    it('allows https and http', () => {
+        expect(safeUrl('https://example.com/x.jpg')).toBe('https://example.com/x.jpg');
+        expect(safeUrl('http://example.com/x.jpg')).toBe('http://example.com/x.jpg');
+    });
+
+    it('allows a same-origin absolute path', () => {
+        // Real catalogue data stores images this way; rejecting it would blank
+        // every existing thumbnail.
+        expect(safeUrl('/images/prod-0001_haven_hart.jpg'))
+            .toBe('/images/prod-0001_haven_hart.jpg');
+    });
+
+    it('preserves query strings and fragments', () => {
+        expect(safeUrl('https://example.com/x?a=1&b=2#frag'))
+            .toBe('https://example.com/x?a=1&b=2#frag');
+    });
+
+    it('honours a custom protocol allowlist', () => {
+        expect(safeUrl('ftp://example.com/x', ['ftp:'])).toBe('ftp://example.com/x');
+        expect(safeUrl('https://example.com/x', ['ftp:'])).toBeNull();
+    });
+});
+
+describe('safeUrl — malformed input', () => {
+    it('rejects an empty or whitespace-only value', () => {
+        expect(safeUrl('')).toBeNull();
+        expect(safeUrl('   ')).toBeNull();
+    });
+
+    it('rejects an unparseable value', () => {
+        expect(safeUrl('not a url')).toBeNull();
+        expect(safeUrl('http://')).toBeNull();
+    });
+
+    it('rejects a bare relative reference', () => {
+        // No base URL is used, so this cannot be resolved safely. Falling back to
+        // text is the correct answer.
+        expect(safeUrl('images/x.jpg')).toBeNull();
+    });
+
+    it('never touches window, so it is safe during server rendering', () => {
+        // The component using this is a client component that Next server-renders,
+        // where `window` is undefined. These tests run in vitest's node
+        // environment, so passing here is itself the assertion.
+        expect(typeof globalThis.window).toBe('undefined');
+        expect(safeUrl('https://example.com')).toBe('https://example.com/');
+    });
+});
+
+// ============================================================================
+// safeMailto
+// ============================================================================
+
+describe('safeMailto', () => {
+    it('builds a mailto for a valid address', () => {
+        expect(safeMailto('a@b.com')).toBe('mailto:a@b.com');
+        expect(safeMailto('  first.last@example.co.uk  ')).toBe('mailto:first.last@example.co.uk');
+    });
+
+    it('rejects anything that is not an address', () => {
+        expect(safeMailto('not-an-address')).toBeNull();
+        expect(safeMailto('')).toBeNull();
+        expect(safeMailto('a@b')).toBeNull();
+        expect(safeMailto('a b@c.com')).toBeNull();
+    });
+
+    it('rejects a value smuggling its own scheme', () => {
+        // Without the shape check this would be pasted straight into the href.
+        expect(safeMailto('javascript:alert(1)')).toBeNull();
+        expect(safeMailto('a@b.com?body=x javascript:alert(1)')).toBeNull();
+    });
+});

--- a/backend/src/shared/utils/safe-url.test.ts
+++ b/backend/src/shared/utils/safe-url.test.ts
@@ -32,6 +32,22 @@ describe('safeUrl — schemes that must be blocked', () => {
     it('rejects leading whitespace used to disguise a scheme', () => {
         expect(safeUrl('  javascript:alert(1)')).toBeNull();
     });
+
+    it('rejects a backslash masquerading as a same-origin path', () => {
+        // Browsers normalise "\\" to "/", so "/\evil.com/x.jpg" resolves
+        // cross-origin even though it starts with a single slash. Checking the raw
+        // string let this straight past the protocol-relative guard.
+        expect(safeUrl('/\\evil.com/x.jpg')).toBeNull();
+        expect(safeUrl('\\\\evil.com/x.jpg')).toBeNull();
+        expect(safeUrl('/\\/evil.com/x.jpg')).toBeNull();
+    });
+
+    it('rejects a scheme split by control characters', () => {
+        // Browsers strip tab/newline/CR from URLs before resolving them.
+        expect(safeUrl('java\nscript:alert(1)')).toBeNull();
+        expect(safeUrl('java\tscript:alert(1)')).toBeNull();
+        expect(safeUrl('java\rscript:alert(1)')).toBeNull();
+    });
 });
 
 describe('safeUrl — values that must keep working', () => {

--- a/backend/src/shared/utils/safe-url.ts
+++ b/backend/src/shared/utils/safe-url.ts
@@ -1,0 +1,84 @@
+// src/shared/utils/safe-url.ts
+
+/**
+ * URL Safety
+ *
+ * Validates a URL before it is rendered into a DOM attribute.
+ *
+ * Needed wherever indexed document content reaches an `href` or `src`: whoever can
+ * write to an index then controls that attribute, and since ingestion keys made the
+ * document write path reachable server-to-server, index content is not necessarily
+ * something a maintainer vetted.
+ *
+ * Two concrete risks this closes:
+ * - `javascript:` in an href executes in the viewer's authenticated session. React
+ *   warns on that one scheme, but a framework warning is not a guard, and `data:`
+ *   and friends are not covered by it.
+ * - An `<img src>` fires a request to an arbitrary host the moment a row renders,
+ *   before any click.
+ *
+ * Deliberately free of `window`: these run inside client components that Next also
+ * server-renders, where `window` is undefined, and the tests run in vitest's node
+ * environment.
+ */
+
+/** Schemes allowed for a link or image by default. */
+const DEFAULT_ALLOWED_PROTOCOLS = ['http:', 'https:'] as const;
+
+/** Shape check for an email address — deliberately loose, just enough to reject junk. */
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/**
+ * Return a URL safe to put in an `href` or `src`, or null if it is not.
+ *
+ * Same-origin relative paths are allowed as-is: catalogues routinely store images
+ * as `/images/foo.jpg`, and rejecting those would blank every such thumbnail. A
+ * protocol-relative `//host/path` is NOT treated as relative — it silently adopts
+ * the page's scheme and points at another origin, which is exactly the kind of
+ * redirection this function exists to stop.
+ *
+ * @param raw - The candidate URL, straight from document content
+ * @param allow - Permitted protocols, including the trailing colon
+ * @returns The URL to render, or null to fall back to plain text
+ */
+export function safeUrl(
+    raw: string,
+    allow: readonly string[] = DEFAULT_ALLOWED_PROTOCOLS,
+): string | null {
+    const trimmed = raw.trim();
+
+    if (trimmed.length === 0) {
+        return null;
+    }
+
+    // Protocol-relative: rejected before the relative check below would accept it.
+    if (trimmed.startsWith('//')) {
+        return null;
+    }
+
+    // Same-origin absolute path.
+    if (trimmed.startsWith('/')) {
+        return trimmed;
+    }
+
+    try {
+        // No base URL on purpose: a bare relative reference like "images/x.jpg"
+        // throws here and falls through to null, which is the safe answer. It also
+        // keeps this usable during server rendering, where there is no origin.
+        const parsed = new URL(trimmed);
+        return allow.includes(parsed.protocol) ? parsed.href : null;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Return a `mailto:` link for a valid-looking address, or null.
+ *
+ * Without the shape check, an arbitrary string is pasted into the scheme — and a
+ * value containing its own scheme is precisely the case worth blocking.
+ */
+export function safeMailto(raw: string): string | null {
+    const trimmed = raw.trim();
+    return EMAIL_PATTERN.test(trimmed) ? `mailto:${trimmed}` : null;
+}

--- a/backend/src/shared/utils/safe-url.ts
+++ b/backend/src/shared/utils/safe-url.ts
@@ -51,21 +51,34 @@ export function safeUrl(
         return null;
     }
 
+    // Normalise the way a browser will before deciding anything.
+    //
+    // Browsers strip tab/newline/carriage return anywhere in a URL and treat a
+    // backslash as a forward slash. Checking the raw string instead let both
+    // smuggle a value past the guards below: "/\evil.com/x.jpg" looked like a
+    // same-origin path here, but resolves cross-origin once rendered, and
+    // "java\nscript:" hid a blocked scheme from the protocol check.
+    const normalized = trimmed.replace(/[\t\n\r]/g, '').replace(/\\/g, '/');
+
+    if (normalized.length === 0) {
+        return null;
+    }
+
     // Protocol-relative: rejected before the relative check below would accept it.
-    if (trimmed.startsWith('//')) {
+    if (normalized.startsWith('//')) {
         return null;
     }
 
     // Same-origin absolute path.
-    if (trimmed.startsWith('/')) {
-        return trimmed;
+    if (normalized.startsWith('/')) {
+        return normalized;
     }
 
     try {
         // No base URL on purpose: a bare relative reference like "images/x.jpg"
         // throws here and falls through to null, which is the safe answer. It also
         // keeps this usable during server rendering, where there is no origin.
-        const parsed = new URL(trimmed);
+        const parsed = new URL(normalized);
         return allow.includes(parsed.protocol) ? parsed.href : null;
     } catch {
         return null;


### PR DESCRIPTION
Makes the Documents browse table schema-agnostic. Column selection previously took
`uniqueId` plus the *first four* retrievable fields in field-definition order, which on
fashion-catalog produced `createdAt, language, updatedAt, ageGroup` — three system-metadata
columns and no product name. Columns are now derived from the index's own field metadata and
laid out as identity → detail → recency: key, a role-inferred title, up to three attributes
ranked by how well their `fieldType` fits a table cell (facetable fields win ties, since few
distinct values means a scannable column), then `updatedAt`. Vector-source fields stay
excluded. Each column now carries its `type`, so cells render as thumbnails, links, formatted
dates and `N items` chips instead of `JSON.stringify` output. No configuration, no new DB
column — change which fields are searchable or facetable and the table follows.

