### PR TITLE
fix: correct post-#28 record — orphan column, API spec, Storyblok guide

### DIFF
--- a/backend/db/drizzle/0026_drop_orphan_ingest_token.sql
+++ b/backend/db/drizzle/0026_drop_orphan_ingest_token.sql
@@ -1,0 +1,19 @@
+-- Drop the orphaned per-index ingestion token left behind by PR #28.
+--
+-- Background: the original 0025 added search_index.ingest_token (PR #17). PR #28
+-- replaced that credential model with the hashed, scoped ingestion_keys tables
+-- and rewrote migration 0025 in place instead of adding a new one. Databases
+-- that had already applied the original 0025 therefore still carry the column,
+-- its unique constraint and its index, while freshly-migrated databases never
+-- create them — and because neither the Drizzle schema nor the 0025 snapshot
+-- mentions the column any more, drizzle-kit will never generate a drop for it.
+--
+-- This migration converges the two. IF EXISTS makes it a no-op on a fresh
+-- database and a cleanup on an existing one. Dropping the column also drops the
+-- dependent search_index_ingest_token_idx index and the
+-- search_index_ingest_token_unique constraint, so those need no statements.
+--
+-- No data is at risk: nothing reads ingest_token. The code that did was removed
+-- in PR #28, so any integration still presenting one of those tokens is already
+-- failing today.
+ALTER TABLE "search_index" DROP COLUMN IF EXISTS "ingest_token";

--- a/backend/db/drizzle/meta/0026_snapshot.json
+++ b/backend/db/drizzle/meta/0026_snapshot.json
@@ -1,0 +1,4992 @@
+{
+  "id": "7628503d-433a-4a80-9740-ac1b7851cfd7",
+  "prevId": "dd9d5dcc-6a80-4b98-9720-6094d780b5a9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "firstName": {
+          "name": "firstName",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastName": {
+          "name": "lastName",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.search_index": {
+      "name": "search_index",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_template_id": {
+          "name": "data_template_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_type": {
+          "name": "search_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "indexing_strategy": {
+          "name": "indexing_strategy",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'on_upload'"
+        },
+        "search_provider": {
+          "name": "search_provider",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'elasticsearch'"
+        },
+        "provider_settings": {
+          "name": "provider_settings",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::json"
+        },
+        "number_of_shards": {
+          "name": "number_of_shards",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "number_of_replicas": {
+          "name": "number_of_replicas",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "refresh_interval": {
+          "name": "refresh_interval",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1s'"
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'english'"
+        },
+        "synonyms": {
+          "name": "synonyms",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::json"
+        },
+        "stop_words": {
+          "name": "stop_words",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::json"
+        },
+        "analyzer_config": {
+          "name": "analyzer_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::json"
+        },
+        "ai_provider_id": {
+          "name": "ai_provider_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_model_id": {
+          "name": "ai_model_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_dimensions": {
+          "name": "embedding_dimensions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vector_similarity": {
+          "name": "vector_similarity",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'cosine'"
+        },
+        "rrf_rank_constant": {
+          "name": "rrf_rank_constant",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "rrf_window_size": {
+          "name": "rrf_window_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'creating'"
+        },
+        "document_count": {
+          "name": "document_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "index_size_bytes": {
+          "name": "index_size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "last_indexed_at": {
+          "name": "last_indexed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mapping_version": {
+          "name": "mapping_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "last_mapping_synced_at": {
+          "name": "last_mapping_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requires_reindex": {
+          "name": "requires_reindex",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "search_index_name_idx": {
+          "name": "search_index_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "search_index_search_type_idx": {
+          "name": "search_index_search_type_idx",
+          "columns": [
+            {
+              "expression": "search_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "search_index_status_idx": {
+          "name": "search_index_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "search_index_is_active_idx": {
+          "name": "search_index_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "search_index_ai_provider_id_ai_providers_id_fk": {
+          "name": "search_index_ai_provider_id_ai_providers_id_fk",
+          "tableFrom": "search_index",
+          "columnsFrom": [
+            "ai_provider_id"
+          ],
+          "tableTo": "ai_providers",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "search_index_ai_model_id_ai_provider_models_id_fk": {
+          "name": "search_index_ai_model_id_ai_provider_models_id_fk",
+          "tableFrom": "search_index",
+          "columnsFrom": [
+            "ai_model_id"
+          ],
+          "tableTo": "ai_provider_models",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "search_index_name_unique": {
+          "name": "search_index_name_unique",
+          "columns": [
+            "name"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.search_index_fields": {
+      "name": "search_index_fields",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "search_index_fields_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "byDefault"
+          }
+        },
+        "search_index_id": {
+          "name": "search_index_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_type": {
+          "name": "field_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_template_field_id": {
+          "name": "original_template_field_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system_field": {
+          "name": "is_system_field",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_required": {
+          "name": "is_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_searchable": {
+          "name": "is_searchable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_facetable": {
+          "name": "is_facetable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "include_in_response": {
+          "name": "include_in_response",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "boost_value": {
+          "name": "boost_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "source_field_name": {
+          "name": "source_field_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_field_path": {
+          "name": "source_field_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_mapped": {
+          "name": "is_mapped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_indexed": {
+          "name": "is_indexed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_vector_source": {
+          "name": "is_vector_source",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_autocomplete": {
+          "name": "is_autocomplete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "custom_analyzer": {
+          "name": "custom_analyzer",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_field_settings": {
+          "name": "provider_field_settings",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::json"
+        },
+        "transform_config": {
+          "name": "transform_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"type\":\"none\"}'::json"
+        },
+        "filter_value_mappings": {
+          "name": "filter_value_mappings",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::json"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sif_search_index_id": {
+          "name": "idx_sif_search_index_id",
+          "columns": [
+            {
+              "expression": "search_index_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_sif_field_name": {
+          "name": "idx_sif_field_name",
+          "columns": [
+            {
+              "expression": "search_index_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_sif_is_mapped": {
+          "name": "idx_sif_is_mapped",
+          "columns": [
+            {
+              "expression": "search_index_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_mapped",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_sif_is_system_field": {
+          "name": "idx_sif_is_system_field",
+          "columns": [
+            {
+              "expression": "search_index_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_system_field",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "search_index_fields_search_index_id_search_index_id_fk": {
+          "name": "search_index_fields_search_index_id_search_index_id_fk",
+          "tableFrom": "search_index_fields",
+          "columnsFrom": [
+            "search_index_id"
+          ],
+          "tableTo": "search_index",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_sif_field_per_index": {
+          "name": "unique_sif_field_per_index",
+          "columns": [
+            "search_index_id",
+            "field_name"
+          ],
+          "nullsNotDistinct": false
+        },
+        "unique_sif_source_mapping": {
+          "name": "unique_sif_source_mapping",
+          "columns": [
+            "search_index_id",
+            "source_field_name"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.indexing_batches": {
+      "name": "indexing_batches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "search_index_id": {
+          "name": "search_index_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "total_documents": {
+          "name": "total_documents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "processed_documents": {
+          "name": "processed_documents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "indexed_documents": {
+          "name": "indexed_documents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed_documents": {
+          "name": "failed_documents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "errors": {
+          "name": "errors",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::json"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_file_name": {
+          "name": "source_file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_size_bytes": {
+          "name": "source_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_key_id": {
+          "name": "created_by_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "indexing_batches_search_index_id_idx": {
+          "name": "indexing_batches_search_index_id_idx",
+          "columns": [
+            {
+              "expression": "search_index_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "indexing_batches_status_idx": {
+          "name": "indexing_batches_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "indexing_batches_created_at_idx": {
+          "name": "indexing_batches_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "indexing_batches_search_index_id_search_index_id_fk": {
+          "name": "indexing_batches_search_index_id_search_index_id_fk",
+          "tableFrom": "indexing_batches",
+          "columnsFrom": [
+            "search_index_id"
+          ],
+          "tableTo": "search_index",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "indexing_batches_created_by_key_id_ingestion_keys_id_fk": {
+          "name": "indexing_batches_created_by_key_id_ingestion_keys_id_fk",
+          "tableFrom": "indexing_batches",
+          "columnsFrom": [
+            "created_by_key_id"
+          ],
+          "tableTo": "ingestion_keys",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingestion_key_indexes": {
+      "name": "ingestion_key_indexes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "ingestion_key_id": {
+          "name": "ingestion_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_index_id": {
+          "name": "search_index_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ingestion_key_indexes_key_id_idx": {
+          "name": "ingestion_key_indexes_key_id_idx",
+          "columns": [
+            {
+              "expression": "ingestion_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "ingestion_key_indexes_search_index_id_idx": {
+          "name": "ingestion_key_indexes_search_index_id_idx",
+          "columns": [
+            {
+              "expression": "search_index_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "ingestion_key_indexes_ingestion_key_id_ingestion_keys_id_fk": {
+          "name": "ingestion_key_indexes_ingestion_key_id_ingestion_keys_id_fk",
+          "tableFrom": "ingestion_key_indexes",
+          "columnsFrom": [
+            "ingestion_key_id"
+          ],
+          "tableTo": "ingestion_keys",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "ingestion_key_indexes_search_index_id_search_index_id_fk": {
+          "name": "ingestion_key_indexes_search_index_id_search_index_id_fk",
+          "tableFrom": "ingestion_key_indexes",
+          "columnsFrom": [
+            "search_index_id"
+          ],
+          "tableTo": "search_index",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_ingestion_key_index": {
+          "name": "unique_ingestion_key_index",
+          "columns": [
+            "ingestion_key_id",
+            "search_index_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingestion_keys": {
+      "name": "ingestion_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operations": {
+          "name": "operations",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ingestion_keys_key_prefix_idx": {
+          "name": "ingestion_keys_key_prefix_idx",
+          "columns": [
+            {
+              "expression": "key_prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "ingestion_keys_revoked_at_idx": {
+          "name": "ingestion_keys_revoked_at_idx",
+          "columns": [
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ingestion_keys_key_prefix_unique": {
+          "name": "ingestion_keys_key_prefix_unique",
+          "columns": [
+            "key_prefix"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.seed_registry": {
+      "name": "seed_registry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "seed_registry_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "byDefault"
+          }
+        },
+        "seed_type": {
+          "name": "seed_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seed_key": {
+          "name": "seed_key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seeded_at": {
+          "name": "seeded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "seed_registry_type_key_idx": {
+          "name": "seed_registry_type_key_idx",
+          "columns": [
+            {
+              "expression": "seed_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seed_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "seed_registry_type_idx": {
+          "name": "seed_registry_type_idx",
+          "columns": [
+            {
+              "expression": "seed_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_provider_models": {
+      "name": "ai_provider_models",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "ai_provider_models_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "byDefault"
+          }
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_key": {
+          "name": "model_key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(150)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_type": {
+          "name": "model_type",
+          "type": "ai_model_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dimensions": {
+          "name": "dimensions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::json"
+        },
+        "is_available": {
+          "name": "is_available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_discovered": {
+          "name": "is_discovered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "input_cost_per_million_tokens": {
+          "name": "input_cost_per_million_tokens",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_cost_per_million_tokens": {
+          "name": "output_cost_per_million_tokens",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_provider_models_provider_id_idx": {
+          "name": "ai_provider_models_provider_id_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "ai_provider_models_model_type_idx": {
+          "name": "ai_provider_models_model_type_idx",
+          "columns": [
+            {
+              "expression": "model_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "ai_provider_models_is_available_idx": {
+          "name": "ai_provider_models_is_available_idx",
+          "columns": [
+            {
+              "expression": "is_available",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "ai_provider_models_provider_id_ai_providers_id_fk": {
+          "name": "ai_provider_models_provider_id_ai_providers_id_fk",
+          "tableFrom": "ai_provider_models",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "tableTo": "ai_providers",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ai_provider_models_provider_model_key": {
+          "name": "ai_provider_models_provider_model_key",
+          "columns": [
+            "provider_id",
+            "model_key"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_providers": {
+      "name": "ai_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider_key": {
+          "name": "provider_key",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "ai_provider_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "ai_auth_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::json"
+        },
+        "last_connection_check": {
+          "name": "last_connection_check",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_connection_status": {
+          "name": "last_connection_status",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_providers_provider_key_idx": {
+          "name": "ai_providers_provider_key_idx",
+          "columns": [
+            {
+              "expression": "provider_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "ai_providers_is_enabled_idx": {
+          "name": "ai_providers_is_enabled_idx",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ai_providers_provider_key_unique": {
+          "name": "ai_providers_provider_key_unique",
+          "columns": [
+            "provider_key"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_defaults": {
+      "name": "system_defaults",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "system_defaults_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "byDefault"
+          }
+        },
+        "default_text_provider_id": {
+          "name": "default_text_provider_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_text_model_id": {
+          "name": "default_text_model_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_embedding_provider_id": {
+          "name": "default_embedding_provider_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_embedding_model_id": {
+          "name": "default_embedding_model_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_chat_provider_id": {
+          "name": "default_chat_provider_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_chat_model_id": {
+          "name": "default_chat_model_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "system_defaults_default_text_provider_id_ai_providers_id_fk": {
+          "name": "system_defaults_default_text_provider_id_ai_providers_id_fk",
+          "tableFrom": "system_defaults",
+          "columnsFrom": [
+            "default_text_provider_id"
+          ],
+          "tableTo": "ai_providers",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "system_defaults_default_text_model_id_ai_provider_models_id_fk": {
+          "name": "system_defaults_default_text_model_id_ai_provider_models_id_fk",
+          "tableFrom": "system_defaults",
+          "columnsFrom": [
+            "default_text_model_id"
+          ],
+          "tableTo": "ai_provider_models",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "system_defaults_default_embedding_provider_id_ai_providers_id_fk": {
+          "name": "system_defaults_default_embedding_provider_id_ai_providers_id_fk",
+          "tableFrom": "system_defaults",
+          "columnsFrom": [
+            "default_embedding_provider_id"
+          ],
+          "tableTo": "ai_providers",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "system_defaults_default_embedding_model_id_ai_provider_models_id_fk": {
+          "name": "system_defaults_default_embedding_model_id_ai_provider_models_id_fk",
+          "tableFrom": "system_defaults",
+          "columnsFrom": [
+            "default_embedding_model_id"
+          ],
+          "tableTo": "ai_provider_models",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "system_defaults_default_chat_provider_id_ai_providers_id_fk": {
+          "name": "system_defaults_default_chat_provider_id_ai_providers_id_fk",
+          "tableFrom": "system_defaults",
+          "columnsFrom": [
+            "default_chat_provider_id"
+          ],
+          "tableTo": "ai_providers",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "system_defaults_default_chat_model_id_ai_provider_models_id_fk": {
+          "name": "system_defaults_default_chat_model_id_ai_provider_models_id_fk",
+          "tableFrom": "system_defaults",
+          "columnsFrom": [
+            "default_chat_model_id"
+          ],
+          "tableTo": "ai_provider_models",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.search_experience_indexes": {
+      "name": "search_experience_indexes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "search_experience_id": {
+          "name": "search_experience_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_index_id": {
+          "name": "search_index_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'primary'"
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ai_description": {
+          "name": "ai_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "se_indexes_experience_idx": {
+          "name": "se_indexes_experience_idx",
+          "columns": [
+            {
+              "expression": "search_experience_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "se_indexes_search_index_idx": {
+          "name": "se_indexes_search_index_idx",
+          "columns": [
+            {
+              "expression": "search_index_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "search_experience_indexes_search_experience_id_search_experiences_id_fk": {
+          "name": "search_experience_indexes_search_experience_id_search_experiences_id_fk",
+          "tableFrom": "search_experience_indexes",
+          "columnsFrom": [
+            "search_experience_id"
+          ],
+          "tableTo": "search_experiences",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "search_experience_indexes_search_index_id_search_index_id_fk": {
+          "name": "search_experience_indexes_search_index_id_search_index_id_fk",
+          "tableFrom": "search_experience_indexes",
+          "columnsFrom": [
+            "search_index_id"
+          ],
+          "tableTo": "search_index",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "se_indexes_unique": {
+          "name": "se_indexes_unique",
+          "columns": [
+            "search_experience_id",
+            "search_index_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.search_experiences": {
+      "name": "search_experiences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_config": {
+          "name": "search_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_config": {
+          "name": "ai_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tools_config": {
+          "name": "tools_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "allowed_origins": {
+          "name": "allowed_origins",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::json"
+        },
+        "rate_limit_config": {
+          "name": "rate_limit_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_config": {
+          "name": "display_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "telemetry_detail_level": {
+          "name": "telemetry_detail_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'off'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "search_experiences_slug_idx": {
+          "name": "search_experiences_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "search_experiences_access_token_idx": {
+          "name": "search_experiences_access_token_idx",
+          "columns": [
+            {
+              "expression": "access_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "search_experiences_is_active_idx": {
+          "name": "search_experiences_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "search_experiences_telemetry_detail_level_idx": {
+          "name": "search_experiences_telemetry_detail_level_idx",
+          "columns": [
+            {
+              "expression": "telemetry_detail_level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "search_experiences_created_by_idx": {
+          "name": "search_experiences_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "search_experiences_slug_unique": {
+          "name": "search_experiences_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "nullsNotDistinct": false
+        },
+        "search_experiences_access_token_unique": {
+          "name": "search_experiences_access_token_unique",
+          "columns": [
+            "access_token"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.global_search_settings": {
+      "name": "global_search_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "search_timeout": {
+          "name": "search_timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30000
+        },
+        "rrf_rank_constant": {
+          "name": "rrf_rank_constant",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "rrf_window_size": {
+          "name": "rrf_window_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "lexical_weight": {
+          "name": "lexical_weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "semantic_weight": {
+          "name": "semantic_weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_knowledge": {
+      "name": "domain_knowledge",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "search_index_id": {
+          "name": "search_index_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "domain_knowledge_search_index_idx": {
+          "name": "domain_knowledge_search_index_idx",
+          "columns": [
+            {
+              "expression": "search_index_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "domain_knowledge_is_active_idx": {
+          "name": "domain_knowledge_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "domain_knowledge_search_index_active_idx": {
+          "name": "domain_knowledge_search_index_active_idx",
+          "columns": [
+            {
+              "expression": "search_index_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "domain_knowledge_search_index_id_search_index_id_fk": {
+          "name": "domain_knowledge_search_index_id_search_index_id_fk",
+          "tableFrom": "domain_knowledge",
+          "columnsFrom": [
+            "search_index_id"
+          ],
+          "tableTo": "search_index",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.data_sources": {
+      "name": "data_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "data_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema": {
+          "name": "schema",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_index_id": {
+          "name": "search_index_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "data_source_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "last_health_check_at": {
+          "name": "last_health_check_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_health_message": {
+          "name": "last_health_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_count": {
+          "name": "document_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_size_bytes": {
+          "name": "storage_size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "data_sources_slug_idx": {
+          "name": "data_sources_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "data_sources_type_idx": {
+          "name": "data_sources_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "data_sources_status_idx": {
+          "name": "data_sources_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "data_sources_is_active_idx": {
+          "name": "data_sources_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "data_sources_search_index_id_idx": {
+          "name": "data_sources_search_index_id_idx",
+          "columns": [
+            {
+              "expression": "search_index_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "data_sources_search_index_id_search_index_id_fk": {
+          "name": "data_sources_search_index_id_search_index_id_fk",
+          "tableFrom": "data_sources",
+          "columnsFrom": [
+            "search_index_id"
+          ],
+          "tableTo": "search_index",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "data_sources_slug_unique": {
+          "name": "data_sources_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tools": {
+      "name": "tools",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executor_type": {
+          "name": "executor_type",
+          "type": "executor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'data_source'"
+        },
+        "operation": {
+          "name": "operation",
+          "type": "data_source_operation",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executor_config": {
+          "name": "executor_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_description": {
+          "name": "ai_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_schema": {
+          "name": "input_schema",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_schema": {
+          "name": "output_schema",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_config": {
+          "name": "display_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeout": {
+          "name": "timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30000
+        },
+        "retry_config": {
+          "name": "retry_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"count\":2,\"backoff\":\"exponential\"}'::json"
+        },
+        "fallback_config": {
+          "name": "fallback_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "health_check_config": {
+          "name": "health_check_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_source_id": {
+          "name": "data_source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "tool_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "last_health_check_at": {
+          "name": "last_health_check_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_health_message": {
+          "name": "last_health_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tools_slug_idx": {
+          "name": "tools_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "tools_executor_type_idx": {
+          "name": "tools_executor_type_idx",
+          "columns": [
+            {
+              "expression": "executor_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "tools_operation_idx": {
+          "name": "tools_operation_idx",
+          "columns": [
+            {
+              "expression": "operation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "tools_status_idx": {
+          "name": "tools_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "tools_is_active_idx": {
+          "name": "tools_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "tools_is_system_idx": {
+          "name": "tools_is_system_idx",
+          "columns": [
+            {
+              "expression": "is_system",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "tools_data_source_id_idx": {
+          "name": "tools_data_source_id_idx",
+          "columns": [
+            {
+              "expression": "data_source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "tools_created_at_idx": {
+          "name": "tools_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "tools_data_source_id_data_sources_id_fk": {
+          "name": "tools_data_source_id_data_sources_id_fk",
+          "tableFrom": "tools",
+          "columnsFrom": [
+            "data_source_id"
+          ],
+          "tableTo": "data_sources",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tools_slug_unique": {
+          "name": "tools_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_experience_tools": {
+      "name": "ai_experience_tools",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "ai_experience_id": {
+          "name": "ai_experience_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_id": {
+          "name": "tool_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "override_ai_description": {
+          "name": "override_ai_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "override_config": {
+          "name": "override_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "aet_experience_idx": {
+          "name": "aet_experience_idx",
+          "columns": [
+            {
+              "expression": "ai_experience_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "aet_tool_idx": {
+          "name": "aet_tool_idx",
+          "columns": [
+            {
+              "expression": "tool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "ai_experience_tools_ai_experience_id_ai_experiences_id_fk": {
+          "name": "ai_experience_tools_ai_experience_id_ai_experiences_id_fk",
+          "tableFrom": "ai_experience_tools",
+          "columnsFrom": [
+            "ai_experience_id"
+          ],
+          "tableTo": "ai_experiences",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "ai_experience_tools_tool_id_tools_id_fk": {
+          "name": "ai_experience_tools_tool_id_tools_id_fk",
+          "tableFrom": "ai_experience_tools",
+          "columnsFrom": [
+            "tool_id"
+          ],
+          "tableTo": "tools",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "aet_experience_tool_unique": {
+          "name": "aet_experience_tool_unique",
+          "columns": [
+            "ai_experience_id",
+            "tool_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_experiences": {
+      "name": "ai_experiences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pipeline_mode": {
+          "name": "pipeline_mode",
+          "type": "pipeline_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'deterministic'"
+        },
+        "pipeline_config": {
+          "name": "pipeline_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentic_config": {
+          "name": "agentic_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "persona_config": {
+          "name": "persona_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guardrail_config": {
+          "name": "guardrail_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_config": {
+          "name": "session_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "access_config": {
+          "name": "access_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observability_config": {
+          "name": "observability_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ai_experiences_slug_idx": {
+          "name": "ai_experiences_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "ai_experiences_access_token_idx": {
+          "name": "ai_experiences_access_token_idx",
+          "columns": [
+            {
+              "expression": "access_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "ai_experiences_is_active_idx": {
+          "name": "ai_experiences_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "ai_experiences_pipeline_mode_idx": {
+          "name": "ai_experiences_pipeline_mode_idx",
+          "columns": [
+            {
+              "expression": "pipeline_mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "ai_experiences_created_at_idx": {
+          "name": "ai_experiences_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ai_experiences_slug_unique": {
+          "name": "ai_experiences_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "nullsNotDistinct": false
+        },
+        "ai_experiences_access_token_unique": {
+          "name": "ai_experiences_access_token_unique",
+          "columns": [
+            "access_token"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_experience_mcp_connections": {
+      "name": "ai_experience_mcp_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "ai_experience_id": {
+          "name": "ai_experience_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mcp_connection_id": {
+          "name": "mcp_connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled_tool_names": {
+          "name": "enabled_tool_names",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "aemc_experience_idx": {
+          "name": "aemc_experience_idx",
+          "columns": [
+            {
+              "expression": "ai_experience_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "aemc_connection_idx": {
+          "name": "aemc_connection_idx",
+          "columns": [
+            {
+              "expression": "mcp_connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "ai_experience_mcp_connections_ai_experience_id_ai_experiences_id_fk": {
+          "name": "ai_experience_mcp_connections_ai_experience_id_ai_experiences_id_fk",
+          "tableFrom": "ai_experience_mcp_connections",
+          "columnsFrom": [
+            "ai_experience_id"
+          ],
+          "tableTo": "ai_experiences",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "ai_experience_mcp_connections_mcp_connection_id_mcp_connections_id_fk": {
+          "name": "ai_experience_mcp_connections_mcp_connection_id_mcp_connections_id_fk",
+          "tableFrom": "ai_experience_mcp_connections",
+          "columnsFrom": [
+            "mcp_connection_id"
+          ],
+          "tableTo": "mcp_connections",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "aemc_experience_connection_unique": {
+          "name": "aemc_experience_connection_unique",
+          "columns": [
+            "ai_experience_id",
+            "mcp_connection_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_connections": {
+      "name": "mcp_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "server_url": {
+          "name": "server_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transport": {
+          "name": "transport",
+          "type": "mcp_transport",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'streamable-http'"
+        },
+        "auth_config": {
+          "name": "auth_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discovered_tools": {
+          "name": "discovered_tools",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_discovered_at": {
+          "name": "last_discovered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "mcp_connection_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "last_health_check_at": {
+          "name": "last_health_check_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_health_message": {
+          "name": "last_health_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_connections_slug_idx": {
+          "name": "mcp_connections_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "mcp_connections_status_idx": {
+          "name": "mcp_connections_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "mcp_connections_is_active_idx": {
+          "name": "mcp_connections_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_connections_slug_unique": {
+          "name": "mcp_connections_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_session_messages": {
+      "name": "ai_session_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "session_message_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "turn_index": {
+          "name": "turn_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ai_session_messages_session_idx": {
+          "name": "ai_session_messages_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "ai_session_messages_session_turn_idx": {
+          "name": "ai_session_messages_session_turn_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "turn_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "ai_session_messages_session_role_idx": {
+          "name": "ai_session_messages_session_role_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "ai_session_messages_created_at_idx": {
+          "name": "ai_session_messages_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "ai_session_messages_embedding_idx": {
+          "name": "ai_session_messages_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "hnsw",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "ai_session_messages_session_id_ai_sessions_id_fk": {
+          "name": "ai_session_messages_session_id_ai_sessions_id_fk",
+          "tableFrom": "ai_session_messages",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "tableTo": "ai_sessions",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_sessions": {
+      "name": "ai_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "ai_experience_id": {
+          "name": "ai_experience_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "facts": {
+          "name": "facts",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::json"
+        },
+        "pipeline_state": {
+          "name": "pipeline_state",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::json"
+        },
+        "last_tool_results": {
+          "name": "last_tool_results",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::json"
+        },
+        "user_context": {
+          "name": "user_context",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "summarized_up_to": {
+          "name": "summarized_up_to",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "client_metadata": {
+          "name": "client_metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ai_sessions_experience_idx": {
+          "name": "ai_sessions_experience_idx",
+          "columns": [
+            {
+              "expression": "ai_experience_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "ai_sessions_status_idx": {
+          "name": "ai_sessions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "ai_sessions_last_active_idx": {
+          "name": "ai_sessions_last_active_idx",
+          "columns": [
+            {
+              "expression": "last_active_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "ai_sessions_expires_at_idx": {
+          "name": "ai_sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "ai_sessions_experience_status_idx": {
+          "name": "ai_sessions_experience_status_idx",
+          "columns": [
+            {
+              "expression": "ai_experience_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "ai_sessions_ai_experience_id_ai_experiences_id_fk": {
+          "name": "ai_sessions_ai_experience_id_ai_experiences_id_fk",
+          "tableFrom": "ai_sessions",
+          "columnsFrom": [
+            "ai_experience_id"
+          ],
+          "tableTo": "ai_experiences",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.knowledge_chunks": {
+      "name": "knowledge_chunks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_source_id": {
+          "name": "data_source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "knowledge_chunks_document_idx": {
+          "name": "knowledge_chunks_document_idx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "knowledge_chunks_data_source_idx": {
+          "name": "knowledge_chunks_data_source_idx",
+          "columns": [
+            {
+              "expression": "data_source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "knowledge_chunks_document_chunk_idx": {
+          "name": "knowledge_chunks_document_chunk_idx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chunk_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "knowledge_chunks_embedding_idx": {
+          "name": "knowledge_chunks_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "hnsw",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "knowledge_chunks_document_id_knowledge_documents_id_fk": {
+          "name": "knowledge_chunks_document_id_knowledge_documents_id_fk",
+          "tableFrom": "knowledge_chunks",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "tableTo": "knowledge_documents",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "knowledge_chunks_data_source_id_data_sources_id_fk": {
+          "name": "knowledge_chunks_data_source_id_data_sources_id_fk",
+          "tableFrom": "knowledge_chunks",
+          "columnsFrom": [
+            "data_source_id"
+          ],
+          "tableTo": "data_sources",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.knowledge_documents": {
+      "name": "knowledge_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "data_source_id": {
+          "name": "data_source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "knowledge_document_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "chunk_count": {
+          "name": "chunk_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "knowledge_documents_data_source_idx": {
+          "name": "knowledge_documents_data_source_idx",
+          "columns": [
+            {
+              "expression": "data_source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "knowledge_documents_data_source_status_idx": {
+          "name": "knowledge_documents_data_source_status_idx",
+          "columns": [
+            {
+              "expression": "data_source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "knowledge_documents_data_source_id_data_sources_id_fk": {
+          "name": "knowledge_documents_data_source_id_data_sources_id_fk",
+          "tableFrom": "knowledge_documents",
+          "columnsFrom": [
+            "data_source_id"
+          ],
+          "tableTo": "data_sources",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_memories": {
+      "name": "user_memories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_experience_id": {
+          "name": "ai_experience_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "source_session_id": {
+          "name": "source_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retrieval_count": {
+          "name": "retrieval_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_retrieved_at": {
+          "name": "last_retrieved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_memories_user_experience_idx": {
+          "name": "user_memories_user_experience_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ai_experience_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "user_memories_source_session_idx": {
+          "name": "user_memories_source_session_idx",
+          "columns": [
+            {
+              "expression": "source_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "user_memories_embedding_idx": {
+          "name": "user_memories_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "hnsw",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "user_memories_ai_experience_id_ai_experiences_id_fk": {
+          "name": "user_memories_ai_experience_id_ai_experiences_id_fk",
+          "tableFrom": "user_memories",
+          "columnsFrom": [
+            "ai_experience_id"
+          ],
+          "tableTo": "ai_experiences",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "user_memories_source_session_id_ai_sessions_id_fk": {
+          "name": "user_memories_source_session_id_ai_sessions_id_fk",
+          "tableFrom": "user_memories",
+          "columnsFrom": [
+            "source_session_id"
+          ],
+          "tableTo": "ai_sessions",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.secrets": {
+      "name": "secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "secrets_name_idx": {
+          "name": "secrets_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "secrets_name_unique": {
+          "name": "secrets_name_unique",
+          "columns": [
+            "name"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_experience_prompt_overrides": {
+      "name": "ai_experience_prompt_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "ai_experience_id": {
+          "name": "ai_experience_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step": {
+          "name": "step",
+          "type": "prompt_template_step",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "aepo_experience_idx": {
+          "name": "aepo_experience_idx",
+          "columns": [
+            {
+              "expression": "ai_experience_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "aepo_template_idx": {
+          "name": "aepo_template_idx",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "ai_experience_prompt_overrides_ai_experience_id_ai_experiences_id_fk": {
+          "name": "ai_experience_prompt_overrides_ai_experience_id_ai_experiences_id_fk",
+          "tableFrom": "ai_experience_prompt_overrides",
+          "columnsFrom": [
+            "ai_experience_id"
+          ],
+          "tableTo": "ai_experiences",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "ai_experience_prompt_overrides_template_id_prompt_templates_id_fk": {
+          "name": "ai_experience_prompt_overrides_template_id_prompt_templates_id_fk",
+          "tableFrom": "ai_experience_prompt_overrides",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "tableTo": "prompt_templates",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "aepo_experience_step_unique": {
+          "name": "aepo_experience_step_unique",
+          "columns": [
+            "ai_experience_id",
+            "step"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prompt_templates": {
+      "name": "prompt_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "step": {
+          "name": "step",
+          "type": "prompt_template_step",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "prompt_template_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "is_system_default": {
+          "name": "is_system_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pt_step_version_idx": {
+          "name": "pt_step_version_idx",
+          "columns": [
+            {
+              "expression": "step",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "pt_step_status_idx": {
+          "name": "pt_step_status_idx",
+          "columns": [
+            {
+              "expression": "step",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "pt_parent_idx": {
+          "name": "pt_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "pt_created_at_idx": {
+          "name": "pt_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.ai_auth_type": {
+      "name": "ai_auth_type",
+      "schema": "public",
+      "values": [
+        "api_key",
+        "none",
+        "oauth"
+      ]
+    },
+    "public.ai_model_type": {
+      "name": "ai_model_type",
+      "schema": "public",
+      "values": [
+        "text",
+        "embedding",
+        "chat",
+        "vision"
+      ]
+    },
+    "public.ai_provider_type": {
+      "name": "ai_provider_type",
+      "schema": "public",
+      "values": [
+        "cloud",
+        "local"
+      ]
+    },
+    "public.data_source_field_role": {
+      "name": "data_source_field_role",
+      "schema": "public",
+      "values": [
+        "title",
+        "description",
+        "content",
+        "price",
+        "image",
+        "category",
+        "id",
+        "url",
+        "date"
+      ]
+    },
+    "public.data_source_operation": {
+      "name": "data_source_operation",
+      "schema": "public",
+      "values": [
+        "search",
+        "inspect",
+        "enumerate",
+        "lookup",
+        "query"
+      ]
+    },
+    "public.data_source_status": {
+      "name": "data_source_status",
+      "schema": "public",
+      "values": [
+        "healthy",
+        "degraded",
+        "error",
+        "unknown"
+      ]
+    },
+    "public.data_source_type": {
+      "name": "data_source_type",
+      "schema": "public",
+      "values": [
+        "search_index",
+        "search_index_external",
+        "file_store",
+        "database"
+      ]
+    },
+    "public.executor_type": {
+      "name": "executor_type",
+      "schema": "public",
+      "values": [
+        "data_source",
+        "http",
+        "web_search",
+        "mcp",
+        "ai_call"
+      ]
+    },
+    "public.field_transform_type": {
+      "name": "field_transform_type",
+      "schema": "public",
+      "values": [
+        "none",
+        "lowercase",
+        "uppercase",
+        "trim",
+        "custom"
+      ]
+    },
+    "public.field_type": {
+      "name": "field_type",
+      "schema": "public",
+      "values": [
+        "text",
+        "keyword",
+        "number",
+        "boolean",
+        "date",
+        "datetime",
+        "url",
+        "email",
+        "json",
+        "array",
+        "image_url"
+      ]
+    },
+    "public.index_status": {
+      "name": "index_status",
+      "schema": "public",
+      "values": [
+        "creating",
+        "ready",
+        "indexing",
+        "error",
+        "offline"
+      ]
+    },
+    "public.indexing_strategy": {
+      "name": "indexing_strategy",
+      "schema": "public",
+      "values": [
+        "on_upload",
+        "scheduled",
+        "manual"
+      ]
+    },
+    "public.mcp_connection_status": {
+      "name": "mcp_connection_status",
+      "schema": "public",
+      "values": [
+        "healthy",
+        "degraded",
+        "error",
+        "unknown"
+      ]
+    },
+    "public.mcp_transport": {
+      "name": "mcp_transport",
+      "schema": "public",
+      "values": [
+        "streamable-http",
+        "sse"
+      ]
+    },
+    "public.pipeline_mode": {
+      "name": "pipeline_mode",
+      "schema": "public",
+      "values": [
+        "agentic",
+        "deterministic"
+      ]
+    },
+    "public.prompt_template_status": {
+      "name": "prompt_template_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "active",
+        "archived"
+      ]
+    },
+    "public.prompt_template_step": {
+      "name": "prompt_template_step",
+      "schema": "public",
+      "values": [
+        "turn_planner",
+        "param_extraction",
+        "response_synthesis",
+        "response_synthesis_direct",
+        "response_synthesis_lightweight",
+        "agentic_loop"
+      ]
+    },
+    "public.search_type": {
+      "name": "search_type",
+      "schema": "public",
+      "values": [
+        "lexical",
+        "semantic",
+        "hybrid"
+      ]
+    },
+    "public.session_message_role": {
+      "name": "session_message_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "assistant",
+        "system",
+        "tool_result"
+      ]
+    },
+    "public.session_status": {
+      "name": "session_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "expired",
+        "archived"
+      ]
+    },
+    "public.tool_fallback_type": {
+      "name": "tool_fallback_type",
+      "schema": "public",
+      "values": [
+        "default_response",
+        "alternative_tool",
+        "skip",
+        "error_message"
+      ]
+    },
+    "public.tool_status": {
+      "name": "tool_status",
+      "schema": "public",
+      "values": [
+        "healthy",
+        "degraded",
+        "error",
+        "unknown"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin",
+        "moderator"
+      ]
+    },
+    "public.vector_similarity": {
+      "name": "vector_similarity",
+      "schema": "public",
+      "values": [
+        "cosine",
+        "euclidean",
+        "dot_product"
+      ]
+    },
+    "public.knowledge_document_status": {
+      "name": "knowledge_document_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "ready",
+        "failed"
+      ]
+    }
+  },
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/db/drizzle/meta/_journal.json
+++ b/backend/db/drizzle/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1785898659960,
       "tag": "0025_dizzy_lionheart",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "7",
+      "when": 1785965959153,
+      "tag": "0026_drop_orphan_ingest_token",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/content/docs/Integrations/cms-dxp/storyblok/how-to-integrate-interakt-with-storyblok.md
+++ b/backend/src/content/docs/Integrations/cms-dxp/storyblok/how-to-integrate-interakt-with-storyblok.md
@@ -24,7 +24,7 @@ Storyblok owns the content. Interakt owns search and chat. The job of the integr
    │              │ <────────────────────────    │                  │
    └──────────────┘  (2) story.published         └──────────────────┘
           │              webhook                     │
-          │                                          │ POST /api/v1/search-indexes/{id}/documents
+          │                                          │ POST /api/search-indexes/{id}/documents
           │                                          ▼
           │                                 ┌──────────────────┐
           │                                 │     Interakt     │
@@ -48,7 +48,7 @@ The key design point: **Storyblok's webhook payload is intentionally lightweight
 - A Storyblok **Content Delivery API token** (Settings → Access Tokens — the public `published` token is fine).
 - An Interakt account with:
   - A **Search Index** (you'll create one below).
-  - A per-index **ingestion key** (`X-Api-Key`).
+  - An **ingestion key** scoped to that index, sent as `Authorization: Bearer`.
   - A **Search Experience** and/or **AI (Chat) Experience** with an **access token** for the widgets.
 - A place to run a small webhook handler reachable over HTTPS (a serverless function on Vercel/Netlify/Cloudflare Workers, or any small Node service).
 
@@ -62,9 +62,13 @@ The key design point: **Storyblok's webhook payload is intentionally lightweight
 
 In the Interakt admin console, create a new **Search Index** for your Storyblok content (e.g. `storyblok-content`). Note its **index ID** (a UUID) — you'll need it for ingestion.
 
-### 1.2 Get your ingestion key
+### 1.2 Create an ingestion key
 
-Document ingestion uses a **separate per-index key** from your widget access tokens. Copy the index's **ingestion key** (`X-Api-Key`) from the index settings. Treat it like a secret — it's write access to your index, so it lives only on your server, never in browser code.
+Writing documents uses an **ingestion key**, which is a different credential from the access tokens your widgets use. On the index page, open the **Ingestion Keys** card and create one, granting it the `write` operation (add `delete` too if you plan to remove documents — see [Part 4](#part-4--handle-unpublishes-and-deletes)).
+
+The key is shown **once, at creation time**, and only a hash of it is stored — so copy it straight into your server's environment. If you lose it, revoke that key and create another.
+
+Treat it like a password: it grants write access to your index, so it belongs only on your server, never in browser code. Keys are scoped to the indexes and operations you grant them, and can be revoked individually without disturbing anything else.
 
 ### 1.3 Create your experiences
 
@@ -176,12 +180,12 @@ async function fetchAllStories() {
 
 async function ingest(documents) {
   const res = await fetch(
-    `${INTERAKT_URL}/api/v1/search-indexes/${INDEX_ID}/documents`,
+    `${INTERAKT_URL}/api/search-indexes/${INDEX_ID}/documents`,
     {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        "X-Api-Key": INGEST_KEY,
+        "Authorization": `Bearer ${INGEST_KEY}`,
       },
       body: JSON.stringify({ documents }),
     }
@@ -268,9 +272,12 @@ async function fetchStory(fullSlug) {
 }
 
 async function ingest(documents) {
-  return fetch(`${INTERAKT_URL}/api/v1/search-indexes/${INDEX_ID}/documents`, {
+  return fetch(`${INTERAKT_URL}/api/search-indexes/${INDEX_ID}/documents`, {
     method: "POST",
-    headers: { "Content-Type": "application/json", "X-Api-Key": INGEST_KEY },
+    headers: {
+      "Content-Type": "application/json",
+      "Authorization": `Bearer ${INGEST_KEY}`,
+    },
     body: JSON.stringify({ documents }),
   });
 }
@@ -293,7 +300,8 @@ export default async function handler(req, res) {
       const story = await fetchStory(full_slug);
       await ingest([storyToDocument(story)]);
     } else if (action === "unpublished" || action === "deleted") {
-      // See "Handling unpublish & delete" below.
+      // Delete by the same id you indexed with — see below.
+      await removeDocument(payload.story_id_uuid);
     }
     return res.status(202).json({ ok: true });
   } catch (err) {
@@ -307,17 +315,37 @@ export default async function handler(req, res) {
 
 #### Handling unpublish & delete
 
-The public ingestion endpoint upserts documents; <!-- AUTHOR NOTE: confirm whether a delete-from-index endpoint exists. If it does, document it here. --> if there is no delete endpoint available to you, a reliable pattern is to keep a status field on each document and filter on it in the Search/AI Experience:
+When an editor unpublishes or deletes a story, remove the matching document. Interakt has a delete endpoint that takes the document id, so the mapping stays simple — the Storyblok `uuid` you used as the document id is the same id you delete by.
+
+The ingestion key needs the `delete` operation for this; if you only granted `write` in step 1.2, add it (or create a second key) before wiring this up.
 
 ```js
-// In storyToDocument(), add:
-//   status: "published"
-//
-// On unpublish/delete, re-ingest the same id with status "unpublished":
-await ingest([{ id: payload.story_id_uuid, status: "unpublished" }]);
+// Deleting is idempotent: removing a document that isn't there still
+// reports success, so a replayed webhook is harmless.
+async function removeDocument(documentId) {
+  const res = await fetch(
+    `${INTERAKT_URL}/api/search-indexes/${INDEX_ID}/documents/${documentId}`,
+    {
+      method: "DELETE",
+      headers: { "Authorization": `Bearer ${INGEST_KEY}` },
+    }
+  );
+  if (!res.ok) throw new Error(`Delete failed: ${res.status}`);
+  return res.json();
+}
+
+// In the webhook handler, for story.unpublished / story.deleted:
+await removeDocument(payload.story_id_uuid);
 ```
 
-Then configure the Search Experience to only return documents where `status = "published"`. This keeps unpublished content out of results without needing a hard delete.
+The id you delete by must be the id you indexed with — the story's `uuid`, set in `storyToDocument()`. Note that a deleted story can no longer be fetched from the Content Delivery API, so the uuid has to come from the webhook payload itself.
+
+<!-- AUTHOR NOTE: confirm the exact payload field carrying the story UUID
+     against a real Storyblok webhook (the payload comment above lists
+     story_id, which is the numeric id, not the uuid). -->
+
+
+**If you'd rather keep the content and hide it**, the alternative is a status field — add `status: "published"` in `storyToDocument()`, write `status: "unpublished"` on those events, and configure the Search Experience to only return documents where `status = "published"`. That preserves history at the cost of carrying unpublished content in the index. Prefer a real delete unless you specifically need that.
 
 ---
 

--- a/backend/src/features/public-api/public-api.openapi.ts
+++ b/backend/src/features/public-api/public-api.openapi.ts
@@ -35,7 +35,6 @@ export const registry = new OpenAPIRegistry();
 
 const ACCESS_TOKEN = 'AccessToken';
 const BEARER = 'BearerAuth';
-const INGEST_KEY = 'IngestApiKey';
 
 registry.registerComponent('securitySchemes', ACCESS_TOKEN, {
   type: 'apiKey',
@@ -49,13 +48,6 @@ registry.registerComponent('securitySchemes', BEARER, {
   type: 'http',
   scheme: 'bearer',
   description: 'The same access token may be sent as `Authorization: Bearer <token>` instead of `X-Access-Token`.',
-});
-
-registry.registerComponent('securitySchemes', INGEST_KEY, {
-  type: 'apiKey',
-  in: 'header',
-  name: 'X-Api-Key',
-  description: 'Per-index ingestion API key, used only by the document ingestion endpoint.',
 });
 
 const tokenAuth = [{ [ACCESS_TOKEN]: [] }, { [BEARER]: [] }];
@@ -189,18 +181,6 @@ const embedSnippetResponseSchema = z
     }),
   })
   .openapi('EmbedSnippetResponse');
-
-const ingestResponseSchema = z
-  .object({
-    success: z.literal(true),
-    data: z
-      .object({
-        indexed: z.number().int().optional(),
-        failed: z.number().int().optional(),
-      })
-      .openapi({ description: 'Ingestion outcome counts.' }),
-  })
-  .openapi('IngestResponse');
 
 // SSE streams can't be fully modelled in OpenAPI; document the event envelope.
 const sseDescription =
@@ -340,38 +320,6 @@ registry.registerPath({
   },
 });
 
-registry.registerPath({
-  method: 'post',
-  path: '/api/v1/search-indexes/{id}/documents',
-  tags: ['Ingestion'],
-  summary: 'Ingest documents into an index',
-  description:
-    'Uploads documents for indexing from an external system. Authenticated with a per-index ingestion key (`X-Api-Key` or `Authorization: Bearer`).',
-  security: [{ [INGEST_KEY]: [] }, { [BEARER]: [] }],
-  request: {
-    params: z.object({
-      id: z.string().uuid().openapi({ param: { name: 'id', in: 'path' }, description: 'Search index UUID.' }),
-    }),
-    body: {
-      content: json(
-        z
-          .object({
-            documents: z
-              .array(z.record(z.unknown()))
-              .min(1)
-              .openapi({ description: 'Array of document objects to index.' }),
-          })
-          .openapi('IngestRequest'),
-      ),
-    },
-  },
-  responses: {
-    200: { description: 'Ingestion accepted.', content: json(ingestResponseSchema) },
-    400: errorResponse('Invalid payload.'),
-    401: errorResponse('Missing or invalid ingestion key.'),
-  },
-});
-
 // ============================================================================
 // DOCUMENT BUILDER
 // ============================================================================
@@ -386,14 +334,16 @@ export function buildOpenApiDocument() {
       description:
         'Public, token-authenticated REST API for embedding Interakt search and AI chat into your own applications.\n\n' +
         'All endpoints live under `/api/v1`. Authenticate with your experience’s access token via the `X-Access-Token` ' +
-        'header (or `Authorization: Bearer`). Document ingestion uses a separate per-index `X-Api-Key`.',
+        'header (or `Authorization: Bearer`). Access tokens are read-only.\n\n' +
+        'Writing documents into an index is a separate, server-to-server concern and is not part of this API. ' +
+        'It uses scoped ingestion keys against the admin endpoints under `/api/search-indexes/{id}/documents` — ' +
+        'see the “Load data in bulk” guide in the documentation.',
     },
     servers: [{ url: 'https://admin.interakt.app', description: 'Hosted Interakt' }],
     tags: [
       { name: 'Search', description: 'Query indexes and fetch documents.' },
       { name: 'AI', description: 'AI summaries and chat experiences.' },
       { name: 'Embed', description: 'Drop-in widget embedding.' },
-      { name: 'Ingestion', description: 'Push documents into an index.' },
     ],
   });
 }

--- a/docs-site/static/openapi/interakt-v1.yaml
+++ b/docs-site/static/openapi/interakt-v1.yaml
@@ -9,7 +9,13 @@ info:
 
     All endpoints live under `/api/v1`. Authenticate with your experience’s
     access token via the `X-Access-Token` header (or `Authorization: Bearer`).
-    Document ingestion uses a separate per-index `X-Api-Key`.
+    Access tokens are read-only.
+
+
+    Writing documents into an index is a separate, server-to-server concern and
+    is not part of this API. It uses scoped ingestion keys against the admin
+    endpoints under `/api/search-indexes/{id}/documents` — see the “Load data in
+    bulk” guide in the documentation.
 servers:
   - url: https://admin.interakt.app
     description: Hosted Interakt
@@ -20,8 +26,6 @@ tags:
     description: AI summaries and chat experiences.
   - name: Embed
     description: Drop-in widget embedding.
-  - name: Ingestion
-    description: Push documents into an index.
 components:
   securitySchemes:
     AccessToken:
@@ -35,12 +39,6 @@ components:
       scheme: bearer
       description: "The same access token may be sent as `Authorization: Bearer
         <token>` instead of `X-Access-Token`."
-    IngestApiKey:
-      type: apiKey
-      in: header
-      name: X-Api-Key
-      description: Per-index ingestion API key, used only by the document ingestion
-        endpoint.
   schemas:
     SearchHit:
       type: object
@@ -550,36 +548,6 @@ components:
       required:
         - success
         - data
-    IngestResponse:
-      type: object
-      properties:
-        success:
-          type: boolean
-          enum:
-            - true
-        data:
-          type: object
-          properties:
-            indexed:
-              type: integer
-            failed:
-              type: integer
-          description: Ingestion outcome counts.
-      required:
-        - success
-        - data
-    IngestRequest:
-      type: object
-      properties:
-        documents:
-          type: array
-          items:
-            type: object
-            additionalProperties: {}
-          minItems: 1
-          description: Array of document objects to index.
-      required:
-        - documents
   parameters: {}
 paths:
   /api/v1/search:
@@ -806,49 +774,6 @@ paths:
                 $ref: "#/components/schemas/EmbedSnippetResponse"
         "401":
           description: Missing or invalid access token.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-  /api/v1/search-indexes/{id}/documents:
-    post:
-      tags:
-        - Ingestion
-      summary: Ingest documents into an index
-      description: "Uploads documents for indexing from an external system.
-        Authenticated with a per-index ingestion key (`X-Api-Key` or
-        `Authorization: Bearer`)."
-      security:
-        - IngestApiKey: []
-        - BearerAuth: []
-      parameters:
-        - schema:
-            type: string
-            format: uuid
-            description: Search index UUID.
-          required: true
-          name: id
-          in: path
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/IngestRequest"
-      responses:
-        "200":
-          description: Ingestion accepted.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/IngestResponse"
-        "400":
-          description: Invalid payload.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "401":
-          description: Missing or invalid ingestion key.
           content:
             application/json:
               schema:


### PR DESCRIPTION
Follow-up to #28. Three things that PR left stating something untrue. No runtime behaviour changes — two are user-visible right now.

**Migration 0026 — drop the orphaned `search_index.ingest_token`.** #28 rewrote `0025` in place instead of adding a migration. The original had already shipped, so databases that applied it still carry the column while fresh ones never create it — and since neither the schema nor the rewritten snapshot mentions it, drizzle-kit can't generate the drop itself. `IF EXISTS` makes this a no-op on a fresh database. Scaffolded with `drizzle-kit generate --custom` so the journal and snapshot are wired correctly, then verified by re-running `generate`.

One thing worth recording: Drizzle applies migrations by timestamp, not by index (`pg-core/dialect.js:62`), so the rewritten `0025` did re-run on existing databases. The ingestion-key tables exist and the feature works — only the column lingered. Had it tracked by index, those tables would silently never have been created.

**API spec — drop the deleted endpoint and dead auth scheme.** `POST /api/v1/search-indexes/{id}/documents` was removed in #28 and nothing reads `X-Api-Key` any more, but both were still published on docs.interakt.app. Also removed the now-unused response schema and tag. Regenerated `interakt-v1.yaml` (8 paths → 7).

Worth deciding separately: ingestion moved off `/api/v1` into the admin namespace. If external systems are meant to call it long-term, versioning it now is cheaper than after adoption. This PR only stops the spec lying.

**Storyblok guide — fix every broken instruction.** Corrected the endpoint and switched to `Authorization: Bearer`, and rewrote key setup for the Ingestion Keys card. Resolved the open author note about deletes: a real `DELETE` exists now, so the guide uses it instead of the status-field workaround, which I kept as a documented alternative. Flagged one thing to confirm — the delete uses `story_id_uuid`, but the payload documented just above it lists only the numeric `story_id`.

**Testing.** Lint (0 errors), type-check and the full unit suite (682 passing) reproduced locally. No behavioural code changed.

Not verified: the migration against a live Postgres carrying the old column, since Docker wasn't available here. It's guarded with `IF EXISTS` and drops a column nothing reads, but if you have the stack up it's worth replaying `0025_wonderful_proteus` from history, then `main`, then this branch.

Remaining #28 findings follow as separate PRs: Azure filter validation, write-path robustness, and tests for the document write path.