### PR TITLE
implement nin for Azure and stop silently dropping

### DIFF
--- a/backend/src/app/api/v1/search/[slug]/search/route.ts
+++ b/backend/src/app/api/v1/search/[slug]/search/route.ts
@@ -15,7 +15,13 @@ import { createLogger } from '@/shared/logger/logger';
 import { auth } from '@/features/auth/auth.api.handlers';
 import { flushTelemetry } from '@/features/telemetry';
 import * as searchService from '@/features/search/search.service';
-import type { SearchRequest, SearchResponse, FacetResult, FacetType } from '@/features/search/search.types';
+import type {
+  SearchRequest,
+  SearchResponse,
+  FacetResult,
+  FacetType,
+  SearchErrorCode,
+} from '@/features/search/search.types';
 import { SearchError } from '@/features/search/search.types';
 import * as repository from '@/features/search-experience/search-experience.repository';
 import { publicSearchRequestSchema } from '@/features/search-experience/search-experience.schemas';
@@ -439,10 +445,22 @@ function handleSearchError(error: unknown, slug: string): NextResponse {
   }
 
   if (error instanceof SearchError) {
-    const statusMap: Record<string, number> = {
+    // Typed as Record<SearchErrorCode, …> on purpose: this is the customer-facing
+    // route, and an unmapped code falls through to 500 — so a bad filter, facet or
+    // field name read as "search is down" rather than "your request was invalid".
+    // The exhaustive type means adding a code to the union without deciding its
+    // status here is a compile error instead of a silent 500 in production.
+    const statusMap: Record<SearchErrorCode, number> = {
       INDEX_NOT_FOUND: 404,
       INDEX_NOT_READY: 503,
       INVALID_QUERY: 400,
+      INVALID_FILTER: 400,
+      INVALID_FACET: 400,
+      INVALID_SORT: 400,
+      FIELD_NOT_FOUND: 400,
+      FIELD_NOT_SEARCHABLE: 400,
+      FIELD_NOT_FACETABLE: 400,
+      EMBEDDING_FAILED: 503,
       PROVIDER_ERROR: 503,
       TIMEOUT: 504,
     };

--- a/backend/src/features/search/providers/azure-ai-search/azure-engine.provider.ts
+++ b/backend/src/features/search/providers/azure-ai-search/azure-engine.provider.ts
@@ -22,7 +22,7 @@ import {
 import { registerProviderClass } from '../search-engine-provider.factory';
 import { buildAzureFilter } from './query-builders/filter.builder';
 import type { ProviderCapabilities } from '../provider-capabilities';
-import type { FilterClause, SearchContext } from '../../search.types';
+import { SearchError, type FilterClause, type SearchContext } from '../../search.types';
 
 import type {
     SearchEngineProvider,
@@ -962,10 +962,17 @@ export class AzureEngineProvider implements SearchEngineProvider {
      */
     buildFilterExpression(filters: FilterClause[], context: SearchContext): unknown {
         // No filters would match every document — refuse rather than let a caller
-        // accidentally purge an entire index.
+        // accidentally purge an entire index. buildAzureFilter throws before this
+        // point if any clause was unexpressible, so the filter can't have been
+        // silently weakened on the way here.
         const filter = buildAzureFilter(filters, context.allFields);
         if (!filter) {
-            throw new Error('At least one filter clause is required');
+            // SearchError rather than Error so the API layer answers 400 with this
+            // message instead of an opaque 500.
+            throw new SearchError(
+                'At least one filter clause is required',
+                'INVALID_FILTER',
+            );
         }
         return filter;
     }

--- a/backend/src/features/search/providers/azure-ai-search/query-builders/filter.builder.test.ts
+++ b/backend/src/features/search/providers/azure-ai-search/query-builders/filter.builder.test.ts
@@ -123,3 +123,70 @@ describe('strict vs lenient', () => {
         expect(buildAzureFilterParts([], scalars)).toEqual({ dropped: [] });
     });
 });
+
+describe('partial coercion inside in/nin', () => {
+    // The same silent drop as the top-level bug, one level down: values that fail
+    // to coerce used to be filtered out of the list, so the clause built fine and
+    // the strict wrapper had nothing to catch. For `nin` that removes an
+    // exclusion and widens the filter.
+    const mixed = [10, 'unknown', 30];
+
+    it('refuses a nin whose list has an uncoercible value, rather than excluding fewer', () => {
+        const { odata, dropped } = buildAzureFilterParts(
+            [{ field: 'price', operator: 'nin', value: mixed } as FilterClause],
+            scalars,
+        );
+        expect(odata).toBeUndefined();
+        expect(dropped).toHaveLength(1);
+        expect(dropped[0].reason).toContain('"unknown"');
+    });
+
+    it('never emits a nin that silently excludes only the coercible values', () => {
+        const { odata } = buildAzureFilterParts(
+            [{ field: 'price', operator: 'nin', value: mixed } as FilterClause],
+            scalars,
+        );
+        expect(odata ?? '').not.toContain('price ne 10');
+    });
+
+    it('refuses a mixed in list too, which would otherwise narrow silently', () => {
+        const { odata, dropped } = buildAzureFilterParts(
+            [{ field: 'price', operator: 'in', value: mixed } as FilterClause],
+            scalars,
+        );
+        expect(odata).toBeUndefined();
+        expect(dropped[0].reason).toContain('not coercible');
+    });
+
+    it('throws from the strict wrapper, so a delete path cannot proceed', () => {
+        expect(() =>
+            buildAzureFilter([{ field: 'price', operator: 'nin', value: mixed } as FilterClause], scalars),
+        ).toThrow(SearchError);
+    });
+
+    it('names how many values failed and which', () => {
+        const { dropped } = buildAzureFilterParts(
+            [{ field: 'price', operator: 'nin', value: [1, 'a', 'b'] } as FilterClause],
+            scalars,
+        );
+        expect(dropped[0].reason).toContain('2 of 3');
+        expect(dropped[0].reason).toContain('"a"');
+        expect(dropped[0].reason).toContain('"b"');
+    });
+
+    it('still builds when every value coerces', () => {
+        const odata = buildAzureFilter(
+            [{ field: 'price', operator: 'nin', value: [10, '30'] } as FilterClause],
+            scalars,
+        );
+        expect(odata).toBe('(price ne 10 and price ne 30)');
+    });
+
+    it('leaves collection fields alone — their elements always coerce', () => {
+        const odata = buildAzureFilter(
+            [{ field: 'keywords', operator: 'nin', value: ['a', 10] } as FilterClause],
+            collections,
+        );
+        expect(odata).toBe("keywords/all(t: t ne 'a' and t ne '10')");
+    });
+});

--- a/backend/src/features/search/providers/azure-ai-search/query-builders/filter.builder.test.ts
+++ b/backend/src/features/search/providers/azure-ai-search/query-builders/filter.builder.test.ts
@@ -1,0 +1,125 @@
+// src/features/search/providers/azure-ai-search/query-builders/filter.builder.test.ts
+
+/**
+ * Azure OData filter builder.
+ *
+ * The regression these tests exist for: an unexpressible clause used to be
+ * dropped silently, so `locale eq 'en' AND uniqueId nin [...]` collapsed to
+ * `locale eq 'en'`. A filter set is a conjunction, so losing a term widens it —
+ * and on delete-by-filter that emptied a production index. Anything asserting
+ * "does not silently reduce" below is guarding that.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { buildAzureFilter, buildAzureFilterParts, type FieldTypeLookup } from './filter.builder';
+import { SearchError, type FilterClause } from '../../../search.types';
+
+const types = (entries: Record<string, string>): FieldTypeLookup =>
+    new Map(Object.entries(entries).map(([name, fieldType]) => [name, { fieldType }]));
+
+const scalars = types({ locale: 'keyword', uniqueId: 'keyword', price: 'number' });
+const collections = types({ keywords: 'array' });
+
+describe('nin', () => {
+    it('ANDs ne comparisons for a scalar field', () => {
+        const odata = buildAzureFilter(
+            [{ field: 'uniqueId', operator: 'nin', value: ['a', 'b'] } as FilterClause],
+            scalars,
+        );
+        expect(odata).toBe("(uniqueId ne 'a' and uniqueId ne 'b')");
+    });
+
+    it('uses all/and for a collection field', () => {
+        const odata = buildAzureFilter(
+            [{ field: 'keywords', operator: 'nin', value: ['x', 'y'] } as FilterClause],
+            collections,
+        );
+        expect(odata).toBe("keywords/all(t: t ne 'x' and t ne 'y')");
+    });
+
+    // in and nin are duals; getting the inversion wrong yields a filter that
+    // matches far too much, which is exactly the failure mode being guarded.
+    it('is the inverse of in — or/any becomes and/all', () => {
+        const clause = (operator: 'in' | 'nin'): FilterClause[] => [
+            { field: 'keywords', operator, value: ['x', 'y'] } as FilterClause,
+        ];
+        expect(buildAzureFilter(clause('in'), collections)).toBe(
+            "keywords/any(t: t eq 'x' or t eq 'y')",
+        );
+        expect(buildAzureFilter(clause('nin'), collections)).toBe(
+            "keywords/all(t: t ne 'x' and t ne 'y')",
+        );
+    });
+
+    it('escapes quotes in values', () => {
+        const odata = buildAzureFilter(
+            [{ field: 'uniqueId', operator: 'nin', value: ["it's"] } as FilterClause],
+            scalars,
+        );
+        expect(odata).toBe("(uniqueId ne 'it''s')");
+    });
+
+    it('drops an empty list rather than emitting a filter that matches everything', () => {
+        const { odata, dropped } = buildAzureFilterParts(
+            [{ field: 'uniqueId', operator: 'nin', value: [] } as FilterClause],
+            scalars,
+        );
+        expect(odata).toBeUndefined();
+        expect(dropped).toHaveLength(1);
+    });
+});
+
+describe('the prune filter (regression)', () => {
+    const pruneFilter: FilterClause[] = [
+        { field: 'locale', operator: 'eq', value: 'en' } as FilterClause,
+        { field: 'uniqueId', operator: 'nin', value: ['en_cases_convena'] } as FilterClause,
+    ];
+
+    it('keeps both clauses — never reduces to locale alone', () => {
+        const odata = buildAzureFilter(pruneFilter, scalars);
+        expect(odata).toBe("locale eq 'en' and (uniqueId ne 'en_cases_convena')");
+        expect(odata).not.toBe("locale eq 'en'");
+    });
+
+    it('throws rather than silently narrowing to the surviving clause', () => {
+        const withBadOperator: FilterClause[] = [
+            { field: 'locale', operator: 'eq', value: 'en' } as FilterClause,
+            { field: 'uniqueId', operator: 'notAnOperator', value: ['x'] } as unknown as FilterClause,
+        ];
+        expect(() => buildAzureFilter(withBadOperator, scalars)).toThrow(SearchError);
+    });
+});
+
+describe('strict vs lenient', () => {
+    const unsupported: FilterClause[] = [
+        { field: 'locale', operator: 'wat', value: 'en' } as unknown as FilterClause,
+    ];
+
+    it('buildAzureFilter throws on an unsupported operator', () => {
+        expect(() => buildAzureFilter(unsupported, scalars)).toThrow(/not supported/);
+    });
+
+    it('buildAzureFilterParts reports instead of throwing', () => {
+        const { odata, dropped } = buildAzureFilterParts(unsupported, scalars);
+        expect(odata).toBeUndefined();
+        expect(dropped).toEqual([
+            { field: 'locale', operator: 'wat', reason: expect.stringContaining('not supported') },
+        ]);
+    });
+
+    it('reports a partial drop, keeping the clauses it could express', () => {
+        const mixed: FilterClause[] = [
+            { field: 'locale', operator: 'eq', value: 'en' } as FilterClause,
+            { field: 'price', operator: 'eq', value: 'not-a-number' } as FilterClause,
+        ];
+        const { odata, dropped } = buildAzureFilterParts(mixed, scalars);
+        expect(odata).toBe("locale eq 'en'");
+        expect(dropped).toHaveLength(1);
+        expect(dropped[0].field).toBe('price');
+    });
+
+    it('returns undefined without throwing for no filters', () => {
+        expect(buildAzureFilter([], scalars)).toBeUndefined();
+        expect(buildAzureFilterParts([], scalars)).toEqual({ dropped: [] });
+    });
+});

--- a/backend/src/features/search/providers/azure-ai-search/query-builders/filter.builder.test.ts
+++ b/backend/src/features/search/providers/azure-ai-search/query-builders/filter.builder.test.ts
@@ -129,11 +129,17 @@ describe('partial coercion inside in/nin', () => {
     // to coerce used to be filtered out of the list, so the clause built fine and
     // the strict wrapper had nothing to catch. For `nin` that removes an
     // exclusion and widens the filter.
-    const mixed = [10, 'unknown', 30];
+    //
+    // All-string arrays on purpose. filterValueSchema accepts z.array(z.string())
+    // without regard to the field's declared type, so a UI-built filter list sends
+    // strings for a numeric field and one junk or blank entry is enough. A mixed
+    // array like [10, 'unknown', 30] is rejected by that schema, so it cannot
+    // reach the builder through any validated path and would test nothing real.
+    const partlyJunk = ['10', 'unknown', '30'];
 
     it('refuses a nin whose list has an uncoercible value, rather than excluding fewer', () => {
         const { odata, dropped } = buildAzureFilterParts(
-            [{ field: 'price', operator: 'nin', value: mixed } as FilterClause],
+            [{ field: 'price', operator: 'nin', value: partlyJunk } as FilterClause],
             scalars,
         );
         expect(odata).toBeUndefined();
@@ -143,15 +149,15 @@ describe('partial coercion inside in/nin', () => {
 
     it('never emits a nin that silently excludes only the coercible values', () => {
         const { odata } = buildAzureFilterParts(
-            [{ field: 'price', operator: 'nin', value: mixed } as FilterClause],
+            [{ field: 'price', operator: 'nin', value: partlyJunk } as FilterClause],
             scalars,
         );
         expect(odata ?? '').not.toContain('price ne 10');
     });
 
-    it('refuses a mixed in list too, which would otherwise narrow silently', () => {
+    it('refuses an in list with a junk value too, which would otherwise narrow silently', () => {
         const { odata, dropped } = buildAzureFilterParts(
-            [{ field: 'price', operator: 'in', value: mixed } as FilterClause],
+            [{ field: 'price', operator: 'in', value: partlyJunk } as FilterClause],
             scalars,
         );
         expect(odata).toBeUndefined();
@@ -160,13 +166,13 @@ describe('partial coercion inside in/nin', () => {
 
     it('throws from the strict wrapper, so a delete path cannot proceed', () => {
         expect(() =>
-            buildAzureFilter([{ field: 'price', operator: 'nin', value: mixed } as FilterClause], scalars),
+            buildAzureFilter([{ field: 'price', operator: 'nin', value: partlyJunk } as FilterClause], scalars),
         ).toThrow(SearchError);
     });
 
     it('names how many values failed and which', () => {
         const { dropped } = buildAzureFilterParts(
-            [{ field: 'price', operator: 'nin', value: [1, 'a', 'b'] } as FilterClause],
+            [{ field: 'price', operator: 'nin', value: ['1', 'a', 'b'] } as FilterClause],
             scalars,
         );
         expect(dropped[0].reason).toContain('2 of 3');
@@ -176,15 +182,26 @@ describe('partial coercion inside in/nin', () => {
 
     it('still builds when every value coerces', () => {
         const odata = buildAzureFilter(
-            [{ field: 'price', operator: 'nin', value: [10, '30'] } as FilterClause],
+            [{ field: 'price', operator: 'nin', value: ['10', '30'] } as FilterClause],
             scalars,
         );
         expect(odata).toBe('(price ne 10 and price ne 30)');
     });
 
+    it('refuses a boolean nin with a junk value', () => {
+        // The reviewer's second reachable case: ['true','unknown'] on a boolean
+        // field used to emit `inStock ne true` alone.
+        const { odata, dropped } = buildAzureFilterParts(
+            [{ field: 'inStock', operator: 'nin', value: ['true', 'unknown'] } as FilterClause],
+            types({ inStock: 'boolean' }),
+        );
+        expect(odata).toBeUndefined();
+        expect(dropped[0].reason).toContain('"unknown"');
+    });
+
     it('leaves collection fields alone — their elements always coerce', () => {
         const odata = buildAzureFilter(
-            [{ field: 'keywords', operator: 'nin', value: ['a', 10] } as FilterClause],
+            [{ field: 'keywords', operator: 'nin', value: ['a', '10'] } as FilterClause],
             collections,
         );
         expect(odata).toBe("keywords/all(t: t ne 'a' and t ne '10')");

--- a/backend/src/features/search/providers/azure-ai-search/query-builders/filter.builder.ts
+++ b/backend/src/features/search/providers/azure-ai-search/query-builders/filter.builder.ts
@@ -168,11 +168,9 @@ function buildFilterClause(
                 const conditions = value.map(v => `t eq ${formatCollectionElement(v)}`);
                 return `${field}/any(t: ${conditions.join(' or ')})`;
             }
-            const conditions = value
-                .map(v => formatOperand(v, fieldType))
-                .filter((o): o is string => o !== null)
-                .map(o => `${field} eq ${o}`);
-            return conditions.length > 0 ? `(${conditions.join(' or ')})` : drop(notCoercible);
+            const operands = coerceAll(value, fieldType);
+            if (!Array.isArray(operands)) return operands;
+            return `(${operands.map(o => `${field} eq ${o}`).join(' or ')})`;
         }
 
         // The inverse of `in`, and the inversion is the whole operator: `in` is a
@@ -187,11 +185,9 @@ function buildFilterClause(
                 const conditions = value.map(v => `t ne ${formatCollectionElement(v)}`);
                 return `${field}/all(t: ${conditions.join(' and ')})`;
             }
-            const conditions = value
-                .map(v => formatOperand(v, fieldType))
-                .filter((o): o is string => o !== null)
-                .map(o => `${field} ne ${o}`);
-            return conditions.length > 0 ? `(${conditions.join(' and ')})` : drop(notCoercible);
+            const operands = coerceAll(value, fieldType);
+            if (!Array.isArray(operands)) return operands;
+            return `(${operands.map(o => `${field} ne ${o}`).join(' and ')})`;
         }
 
         case 'exists':
@@ -235,6 +231,42 @@ function getFieldType(field: string, fieldTypes?: FieldTypeLookup): string | und
  * "1275" (quote it), while a number field receives "1100" (emit a bare literal).
  * Returns null when the value can't be coerced to the field's type (clause skipped).
  */
+/**
+ * Coerce every element of an `in`/`nin` list, or report the ones that could not be.
+ *
+ * Emitting the operands that happened to coerce is not a safe fallback. For `nin`
+ * a missing element drops an exclusion and **widens** the filter — the same
+ * failure this module exists to prevent, one level further down, and invisible to
+ * the strict wrapper because the clause itself builds fine. For `in` it narrows
+ * instead. Either direction answers a question the caller did not ask, so the
+ * whole clause is refused and the offending values are named.
+ *
+ * @returns the operands, or a ClauseDrop when any element failed to coerce
+ */
+function coerceAll(values: unknown[], fieldType?: string): string[] | ClauseDrop {
+    const operands: string[] = [];
+    const failed: unknown[] = [];
+
+    for (const v of values) {
+        const operand = formatOperand(v, fieldType);
+        if (operand === null) {
+            failed.push(v);
+        } else {
+            operands.push(operand);
+        }
+    }
+
+    if (failed.length > 0) {
+        const named = failed.map(v => JSON.stringify(v)).join(', ');
+        return drop(
+            `${failed.length} of ${values.length} values not coercible to field type `
+            + `"${fieldType ?? 'unknown'}": ${named}`,
+        );
+    }
+
+    return operands;
+}
+
 function formatOperand(value: unknown, fieldType?: string): string | null {
     switch (fieldType) {
         case 'number': {

--- a/backend/src/features/search/providers/azure-ai-search/query-builders/filter.builder.ts
+++ b/backend/src/features/search/providers/azure-ai-search/query-builders/filter.builder.ts
@@ -8,43 +8,117 @@
  *
  * For Collection fields (e.g., Collection(Edm.String)), Azure requires lambda
  * expressions: `tags/any(t: t eq 'value')` instead of `tags eq 'value'`.
+ *
+ * ## Dropped clauses must never be silent
+ *
+ * A clause this builder cannot express used to be discarded, leaving the
+ * remaining clauses to run on their own. That is safe-looking and badly wrong: a
+ * filter set is a conjunction, so removing a term **widens** it. On a delete
+ * path it is destructive — `locale eq 'en' AND uniqueId nin [...]` collapsed to
+ * `locale eq 'en'`, turning "delete everything except what I just wrote" into
+ * "delete everything", and it emptied a production index exactly that way.
+ *
+ * So translation and policy are separated:
+ *
+ *   - `buildAzureFilterParts` translates and **reports** what it could not
+ *     express. Nothing is lost, nothing throws.
+ *   - `buildAzureFilter` is the strict wrapper and **throws** if anything was
+ *     dropped. Search and delete paths use this, so an unsupported clause is a
+ *     loud 400 rather than a quietly different result set.
+ *
+ * Callers that legitimately want to continue without a clause (the LLM tool
+ * executor, which surfaces them as "unapplied") use the parts form and report
+ * every entry.
  */
 
 import 'server-only';
 
-import type { FilterClause, FieldConfig } from '../../../search.types';
+import { SearchError, type FilterClause, type FieldConfig } from '../../../search.types';
 
 /** Field type lookup — maps field name to its type (e.g., 'array', 'text', 'keyword') */
 export type FieldTypeLookup = Map<string, FieldConfig> | Map<string, { fieldType: string }>;
 
+/** A clause that could not be expressed as OData, and why. */
+export type DroppedClause = {
+    field: string;
+    operator: FilterClause['operator'];
+    reason: string;
+};
+
+export type AzureFilterParts = {
+    /** Undefined when no clause survived. */
+    odata?: string;
+    dropped: DroppedClause[];
+};
+
 /**
- * Build an OData $filter string from search filters.
+ * Translate filters to OData, reporting anything that could not be expressed.
+ *
+ * Never throws — the caller decides whether a dropped clause is acceptable.
+ */
+export function buildAzureFilterParts(
+    filters: FilterClause[],
+    fieldTypes?: FieldTypeLookup,
+): AzureFilterParts {
+    if (!filters || filters.length === 0) return { dropped: [] };
+
+    const clauses: string[] = [];
+    const dropped: DroppedClause[] = [];
+
+    for (const filter of filters) {
+        const result = buildFilterClause(filter, fieldTypes);
+        if (typeof result === 'string') {
+            clauses.push(result);
+        } else {
+            dropped.push({ field: filter.field, operator: filter.operator, reason: result.reason });
+        }
+    }
+
+    return { odata: clauses.length > 0 ? clauses.join(' and ') : undefined, dropped };
+}
+
+/**
+ * Build an OData $filter string, refusing to weaken the filter set.
  *
  * @param filters - Array of filter clauses
  * @param fieldTypes - Optional field type lookup for Collection-aware filtering.
  *   When provided, array-typed fields use lambda expressions (any/all).
+ * @throws SearchError if any clause cannot be expressed as OData.
  */
 export function buildAzureFilter(
     filters: FilterClause[],
     fieldTypes?: FieldTypeLookup,
 ): string | undefined {
-    if (!filters || filters.length === 0) return undefined;
+    const { odata, dropped } = buildAzureFilterParts(filters, fieldTypes);
 
-    const clauses = filters
-        .map(filter => buildFilterClause(filter, fieldTypes))
-        .filter(Boolean);
+    if (dropped.length > 0) {
+        const detail = dropped.map(d => `${d.field} ${d.operator} (${d.reason})`).join('; ');
+        throw new SearchError(
+            `Filter cannot be expressed for Azure AI Search: ${detail}`,
+            'INVALID_FILTER',
+            { dropped },
+        );
+    }
 
-    if (clauses.length === 0) return undefined;
-    return clauses.join(' and ');
+    return odata;
 }
 
-function buildFilterClause(filter: FilterClause, fieldTypes?: FieldTypeLookup): string | null {
+/** Why a clause was dropped. Distinguishable from a built clause by not being a string. */
+type ClauseDrop = { reason: string };
+
+const drop = (reason: string): ClauseDrop => ({ reason });
+
+function buildFilterClause(
+    filter: FilterClause,
+    fieldTypes?: FieldTypeLookup,
+): string | ClauseDrop {
     const { field, operator, value } = filter;
 
-    if (value === undefined || value === null) return null;
+    if (value === undefined || value === null) return drop('value is null or undefined');
 
     const fieldType = getFieldType(field, fieldTypes);
     const isCollection = fieldType === 'array';
+    const notCoercible = `value is not coercible to field type "${fieldType ?? 'unknown'}"`;
 
     switch (operator) {
         case 'eq': {
@@ -53,7 +127,7 @@ function buildFilterClause(filter: FilterClause, fieldTypes?: FieldTypeLookup): 
                 return `${field}/any(t: t eq ${formatCollectionElement(value)})`;
             }
             const operand = formatOperand(value, fieldType);
-            return operand === null ? null : `${field} eq ${operand}`;
+            return operand === null ? drop(notCoercible) : `${field} eq ${operand}`;
         }
 
         case 'neq': {
@@ -62,31 +136,33 @@ function buildFilterClause(filter: FilterClause, fieldTypes?: FieldTypeLookup): 
                 return `${field}/all(t: t ne ${formatCollectionElement(value)})`;
             }
             const operand = formatOperand(value, fieldType);
-            return operand === null ? null : `${field} ne ${operand}`;
+            return operand === null ? drop(notCoercible) : `${field} ne ${operand}`;
         }
 
         case 'gt': {
             const operand = formatOperand(value, fieldType);
-            return operand === null ? null : `${field} gt ${operand}`;
+            return operand === null ? drop(notCoercible) : `${field} gt ${operand}`;
         }
 
         case 'gte': {
             const operand = formatOperand(value, fieldType);
-            return operand === null ? null : `${field} ge ${operand}`;
+            return operand === null ? drop(notCoercible) : `${field} ge ${operand}`;
         }
 
         case 'lt': {
             const operand = formatOperand(value, fieldType);
-            return operand === null ? null : `${field} lt ${operand}`;
+            return operand === null ? drop(notCoercible) : `${field} lt ${operand}`;
         }
 
         case 'lte': {
             const operand = formatOperand(value, fieldType);
-            return operand === null ? null : `${field} le ${operand}`;
+            return operand === null ? drop(notCoercible) : `${field} le ${operand}`;
         }
 
         case 'in': {
-            if (!Array.isArray(value) || value.length === 0) return null;
+            if (!Array.isArray(value) || value.length === 0) {
+                return drop('IN requires a non-empty array');
+            }
             if (isCollection) {
                 // Any item in the collection matches any of the given values
                 const conditions = value.map(v => `t eq ${formatCollectionElement(v)}`);
@@ -96,7 +172,26 @@ function buildFilterClause(filter: FilterClause, fieldTypes?: FieldTypeLookup): 
                 .map(v => formatOperand(v, fieldType))
                 .filter((o): o is string => o !== null)
                 .map(o => `${field} eq ${o}`);
-            return conditions.length > 0 ? `(${conditions.join(' or ')})` : null;
+            return conditions.length > 0 ? `(${conditions.join(' or ')})` : drop(notCoercible);
+        }
+
+        // The inverse of `in`, and the inversion is the whole operator: `in` is a
+        // disjunction of `eq` (any/or), `nin` a conjunction of `ne` (all/and).
+        // Getting that backwards yields a filter that quietly matches too much.
+        case 'nin': {
+            if (!Array.isArray(value) || value.length === 0) {
+                return drop('NIN requires a non-empty array');
+            }
+            if (isCollection) {
+                // No item in the collection matches any of the given values
+                const conditions = value.map(v => `t ne ${formatCollectionElement(v)}`);
+                return `${field}/all(t: ${conditions.join(' and ')})`;
+            }
+            const conditions = value
+                .map(v => formatOperand(v, fieldType))
+                .filter((o): o is string => o !== null)
+                .map(o => `${field} ne ${o}`);
+            return conditions.length > 0 ? `(${conditions.join(' and ')})` : drop(notCoercible);
         }
 
         case 'exists':
@@ -120,11 +215,11 @@ function buildFilterClause(filter: FilterClause, fieldTypes?: FieldTypeLookup): 
             push('gt', range.gt);
             push('le', range.lte);
             push('lt', range.lt);
-            return parts.length > 0 ? parts.join(' and ') : null;
+            return parts.length > 0 ? parts.join(' and ') : drop('range has no usable bounds');
         }
 
         default:
-            return null;
+            return drop(`operator "${operator}" is not supported by Azure AI Search`);
     }
 }
 

--- a/backend/src/features/search/providers/azure-ai-search/query-builders/index.ts
+++ b/backend/src/features/search/providers/azure-ai-search/query-builders/index.ts
@@ -1,4 +1,9 @@
 // src/features/search/providers/azure-ai-search/query-builders/index.ts
 
 export { buildAzureSearchOptions, type AzureSearchOptions, type AzureVectorQuery } from './query.builder';
-export { buildAzureFilter } from './filter.builder';
+export {
+    buildAzureFilter,
+    buildAzureFilterParts,
+    type AzureFilterParts,
+    type DroppedClause,
+} from './filter.builder';

--- a/backend/src/features/tools/executors/external-query.ts
+++ b/backend/src/features/tools/executors/external-query.ts
@@ -9,7 +9,7 @@
  * `filters` or `sort`, so a planned filter was accepted, reported as a success, and had
  * no effect on the results.
  *
- * Operator semantics are NOT reimplemented here — Azure delegates to buildAzureFilter and
+ * Operator semantics are NOT reimplemented here — Azure delegates to buildAzureFilterParts and
  * Elasticsearch to buildOperatorQuery, the same builders the standalone search path uses.
  * What this module owns is the part those builders can't know about: resolving a field
  * against a *discovered* schema, and deciding what to do when the provider cannot express
@@ -20,7 +20,7 @@
  */
 
 import type { DataSourceField } from '@/db/schema/data-sources.schema';
-import { buildAzureFilter } from '@/features/search/providers/azure-ai-search/query-builders/filter.builder';
+import { buildAzureFilterParts } from '@/features/search/providers/azure-ai-search/query-builders/filter.builder';
 import {
   buildOperatorQuery,
   type ESQuery,
@@ -165,22 +165,21 @@ function translateAzureFilters(
 
   if (usable.length === 0) return { unapplied };
 
-  const odata = buildAzureFilter(usable, fieldTypes);
+  // The parts form rather than buildAzureFilter: this executor reports what it
+  // couldn't apply and continues, where the strict wrapper throws. It also
+  // reports *partial* drops — previously only the all-dropped case was noticed,
+  // so a filter set that lost one clause silently returned a wider result set.
+  const { odata, dropped } = buildAzureFilterParts(usable, fieldTypes);
 
-  // buildAzureFilter drops clauses it cannot express (unknown operator, empty `in` list)
-  // and returns undefined when nothing survives. Report that rather than losing it.
-  if (!odata) {
-    for (const filter of usable) {
-      unapplied.push({
-        field: filter.field,
-        operator: filter.operator,
-        reason: 'operator cannot be expressed as an OData filter',
-      });
-    }
-    return { unapplied };
+  for (const clause of dropped) {
+    unapplied.push({
+      field: clause.field,
+      operator: clause.operator,
+      reason: clause.reason,
+    });
   }
 
-  return { odata, unapplied };
+  return odata ? { odata, unapplied } : { unapplied };
 }
 
 function translateAzureSort(sort: SortClause[], lookup: FieldLookup): TranslatedSort {


### PR DESCRIPTION
fix: implement nin for Azure and stop silently dropping filter clauses

The Azure OData builder had no `nin` case, so buildFilterClause returned null and
buildAzureFilter discarded it. Filter clauses AND together, so dropping one widens
the set — on the delete path that turned `locale eq 'en' AND uniqueId nin [...]`
("delete everything except what I just wrote") into `locale eq 'en'`, which emptied
a production index.

Implement `nin`: ANDed `ne` for scalar fields, an `all/and` lambda for collections,
and an empty list is refused rather than emitting a filter that matches everything.

Split translation from policy so this class of failure can't recur silently.
buildAzureFilterParts translates and reports what it couldn't express;
buildAzureFilter throws SearchError('INVALID_FILTER'). Search and delete use the
strict form — an unsupported clause is now a loud 400 rather than a quietly wider
result set. The LLM tool executor uses the parts form and reports partial drops,
which previously went unnoticed because only the all-dropped case was checked.
Adds 11 tests, including a named regression test for the prune filter.
