### PR TITLE
support for  language/stop-word reindexing, and clear reindex flag on…

### DIFF
--- a/backend/src/app/search-indexes/(pages)/[id]/edit/page.tsx
+++ b/backend/src/app/search-indexes/(pages)/[id]/edit/page.tsx
@@ -60,7 +60,7 @@ import {
   SEARCH_TYPE_INFO,
   ES_LANGUAGES,
   REFRESH_INTERVALS,
-  FIELDS_REQUIRING_REINDEX,
+  getReindexFieldsForProvider,
   requiresAIConfiguration,
   type UpdateSearchIndexDTO,
   type IndexingStrategy,
@@ -278,14 +278,11 @@ export default function EditSearchIndexPage() {
   const stopWords = watch('stopWords') || [];
 
   // Check if any dirty fields require reindexing, or if the index already has
-  // a persisted reindex-needed flag from a previous save. Language and stop
-  // words only affect Elasticsearch's analyzer chain — Azure ignores them and
-  // only reads synonyms — so they shouldn't trip "reindex needed" there.
+  // a persisted reindex-needed flag from a previous save. Which fields count is
+  // provider-dependent — see getReindexFieldsForProvider().
   const requiresReindex = useMemo(() => {
     const dirtyFieldNames = Object.keys(dirtyFields);
-    const reindexFields = searchIndex?.searchProvider === 'elasticsearch'
-      ? FIELDS_REQUIRING_REINDEX
-      : ['synonyms'];
+    const reindexFields = getReindexFieldsForProvider(searchIndex?.searchProvider);
     const dirtyRequiresReindex = dirtyFieldNames.some(field =>
       (reindexFields as readonly string[]).includes(field)
     );

--- a/backend/src/app/search-indexes/(pages)/[id]/edit/page.tsx
+++ b/backend/src/app/search-indexes/(pages)/[id]/edit/page.tsx
@@ -277,13 +277,20 @@ export default function EditSearchIndexPage() {
   const synonyms = watch('synonyms') || [];
   const stopWords = watch('stopWords') || [];
 
-  // Check if any dirty fields require reindexing
+  // Check if any dirty fields require reindexing, or if the index already has
+  // a persisted reindex-needed flag from a previous save. Language and stop
+  // words only affect Elasticsearch's analyzer chain — Azure ignores them and
+  // only reads synonyms — so they shouldn't trip "reindex needed" there.
   const requiresReindex = useMemo(() => {
     const dirtyFieldNames = Object.keys(dirtyFields);
-    return dirtyFieldNames.some(field =>
-      FIELDS_REQUIRING_REINDEX.includes(field as typeof FIELDS_REQUIRING_REINDEX[number])
+    const reindexFields = searchIndex?.searchProvider === 'elasticsearch'
+      ? FIELDS_REQUIRING_REINDEX
+      : ['synonyms'];
+    const dirtyRequiresReindex = dirtyFieldNames.some(field =>
+      (reindexFields as readonly string[]).includes(field)
     );
-  }, [dirtyFields]);
+    return dirtyRequiresReindex || !!searchIndex?.requiresReindex;
+  }, [dirtyFields, searchIndex?.requiresReindex, searchIndex?.searchProvider]);
 
   // Populate form when data loads
   useEffect(() => {
@@ -667,44 +674,46 @@ export default function EditSearchIndexPage() {
               </CardContent>
             </Card>
 
-            <Card className="border-border/60 shadow-sm rounded-2xl">
-              <CardHeader className="pb-3">
-                <CardTitle className="text-base flex items-center gap-2 font-semibold">
-                  <Languages className="h-4 w-4 text-blue-500" />
-                  Language Settings
-                </CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                <div className="space-y-2">
-                  <Label className="text-sm font-medium flex items-center gap-2">
-                    Language
-                    {dirtyFields.language && (
-                      <Badge variant="outline" className="text-amber-600 border-amber-300 text-[10px] px-1.5 py-0 rounded-md">
-                        modified
-                      </Badge>
-                    )}
-                  </Label>
-                  <Select
-                    value={language}
-                    onValueChange={(value) => setValue('language', value, { shouldDirty: true })}
-                  >
-                    <SelectTrigger className="rounded-lg">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent className="rounded-xl max-h-64">
-                      {ES_LANGUAGES.map((lang) => (
-                        <SelectItem key={lang.value} value={lang.value} className="rounded-lg">
-                          {lang.label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  <p className="text-xs text-muted-foreground">
-                    Determines stemming, stop words, and text analysis for this language
-                  </p>
-                </div>
-              </CardContent>
-            </Card>
+            {isElasticsearch && (
+              <Card className="border-border/60 shadow-sm rounded-2xl">
+                <CardHeader className="pb-3">
+                  <CardTitle className="text-base flex items-center gap-2 font-semibold">
+                    <Languages className="h-4 w-4 text-blue-500" />
+                    Language Settings
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  <div className="space-y-2">
+                    <Label className="text-sm font-medium flex items-center gap-2">
+                      Language
+                      {dirtyFields.language && (
+                        <Badge variant="outline" className="text-amber-600 border-amber-300 text-[10px] px-1.5 py-0 rounded-md">
+                          modified
+                        </Badge>
+                      )}
+                    </Label>
+                    <Select
+                      value={language}
+                      onValueChange={(value) => setValue('language', value, { shouldDirty: true })}
+                    >
+                      <SelectTrigger className="rounded-lg">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent className="rounded-xl max-h-64">
+                        {ES_LANGUAGES.map((lang) => (
+                          <SelectItem key={lang.value} value={lang.value} className="rounded-lg">
+                            {lang.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <p className="text-xs text-muted-foreground">
+                      Determines stemming, stop words, and text analysis for this language
+                    </p>
+                  </div>
+                </CardContent>
+              </Card>
+            )}
 
             <Card className="border-border/60 shadow-sm rounded-2xl">
               <CardHeader className="pb-3">
@@ -769,68 +778,70 @@ export default function EditSearchIndexPage() {
               </CardContent>
             </Card>
 
-            <Card className="border-border/60 shadow-sm rounded-2xl">
-              <CardHeader className="pb-3">
-                <CardTitle className="text-base flex items-center gap-2 font-semibold">
-                  <X className="h-4 w-4 text-red-500" />
-                  Custom Stop Words
-                  {dirtyFields.stopWords && (
-                    <Badge variant="outline" className="text-amber-600 border-amber-300 text-[10px] px-1.5 py-0 rounded-md">
-                      modified
-                    </Badge>
-                  )}
-                </CardTitle>
-                <CardDescription>
-                  Words to ignore during search (comma-separated)
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                <div className="flex gap-2">
-                  <Input
-                    placeholder="e.g., the, a, an"
-                    value={newStopWord}
-                    onChange={(e) => setNewStopWord(e.target.value)}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter') {
-                        e.preventDefault();
-                        handleAddStopWord();
-                      }
-                    }}
-                    className="rounded-lg"
-                  />
-                  <Button
-                    type="button"
-                    variant="outline"
-                    onClick={handleAddStopWord}
-                    disabled={!newStopWord.trim()}
-                    className="rounded-lg"
-                  >
-                    <Plus className="h-4 w-4" />
-                  </Button>
-                </div>
-                {stopWords.length > 0 && (
-                  <div className="flex flex-wrap gap-2">
-                    {stopWords.map((word, i) => (
-                      <Badge key={i} variant="outline" className="pl-3 pr-1.5 py-1.5 rounded-lg">
-                        <span className="text-xs font-medium">{word}</span>
-                        <button
-                          type="button"
-                          onClick={() => handleRemoveStopWord(i)}
-                          className="ml-2 hover:bg-destructive/20 rounded p-0.5 transition-colors"
-                        >
-                          <X className="h-3 w-3" />
-                        </button>
+            {isElasticsearch && (
+              <Card className="border-border/60 shadow-sm rounded-2xl">
+                <CardHeader className="pb-3">
+                  <CardTitle className="text-base flex items-center gap-2 font-semibold">
+                    <X className="h-4 w-4 text-red-500" />
+                    Custom Stop Words
+                    {dirtyFields.stopWords && (
+                      <Badge variant="outline" className="text-amber-600 border-amber-300 text-[10px] px-1.5 py-0 rounded-md">
+                        modified
                       </Badge>
-                    ))}
+                    )}
+                  </CardTitle>
+                  <CardDescription>
+                    Words to ignore during search (comma-separated)
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  <div className="flex gap-2">
+                    <Input
+                      placeholder="e.g., the, a, an"
+                      value={newStopWord}
+                      onChange={(e) => setNewStopWord(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') {
+                          e.preventDefault();
+                          handleAddStopWord();
+                        }
+                      }}
+                      className="rounded-lg"
+                    />
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={handleAddStopWord}
+                      disabled={!newStopWord.trim()}
+                      className="rounded-lg"
+                    >
+                      <Plus className="h-4 w-4" />
+                    </Button>
                   </div>
-                )}
-                {stopWords.length === 0 && (
-                  <p className="text-sm text-muted-foreground text-center py-4 bg-muted/30 rounded-xl">
-                    No custom stop words configured
-                  </p>
-                )}
-              </CardContent>
-            </Card>
+                  {stopWords.length > 0 && (
+                    <div className="flex flex-wrap gap-2">
+                      {stopWords.map((word, i) => (
+                        <Badge key={i} variant="outline" className="pl-3 pr-1.5 py-1.5 rounded-lg">
+                          <span className="text-xs font-medium">{word}</span>
+                          <button
+                            type="button"
+                            onClick={() => handleRemoveStopWord(i)}
+                            className="ml-2 hover:bg-destructive/20 rounded p-0.5 transition-colors"
+                          >
+                            <X className="h-3 w-3" />
+                          </button>
+                        </Badge>
+                      ))}
+                    </div>
+                  )}
+                  {stopWords.length === 0 && (
+                    <p className="text-sm text-muted-foreground text-center py-4 bg-muted/30 rounded-xl">
+                      No custom stop words configured
+                    </p>
+                  )}
+                </CardContent>
+              </Card>
+            )}
           </TabsContent>
 
           {/* Provider Settings Tab */}

--- a/backend/src/app/search-indexes/(pages)/[id]/mappings/page.tsx
+++ b/backend/src/app/search-indexes/(pages)/[id]/mappings/page.tsx
@@ -242,6 +242,12 @@ export default function FieldMappingsPage() {
     // Track if reindex is needed (saved changes that require ES mapping update)
     const [reindexNeeded, setReindexNeeded] = useState(false);
 
+    // Hydrate from the persisted flag whenever the index record loads/refetches,
+    // so a user reopening this page sees reindex-required state from a prior session
+    useEffect(() => {
+        if (searchIndex) setReindexNeeded(searchIndex.requiresReindex);
+    }, [searchIndex?.requiresReindex]);
+
     // Reindex dialog state
     const [reindexDialogOpen, setReindexDialogOpen] = useState(false);
 

--- a/backend/src/app/search-indexes/(pages)/[id]/page.tsx
+++ b/backend/src/app/search-indexes/(pages)/[id]/page.tsx
@@ -476,6 +476,37 @@ export default function SearchIndexDetailPage() {
         </Card>
       )}
 
+      {/* Reindex Needed Banner */}
+      {syncStatus?.requiresReindex && (
+        <Card className="border-blue-500/30 bg-blue-50/50 dark:bg-blue-950/20 shadow-sm rounded-2xl">
+          <CardContent className="p-4">
+            <div className="flex items-start gap-3">
+              <div className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-blue-500/15">
+                <RefreshCw className="size-5 text-blue-600" />
+              </div>
+              <div className="flex-1 min-w-0">
+                <p className="font-medium text-sm text-blue-900 dark:text-blue-200">
+                  Reindex needed
+                </p>
+                <p className="text-xs text-blue-700 dark:text-blue-400 mt-0.5">
+                  Text analysis or field mapping settings changed since the last reindex. Reindex to apply them to the provider index.
+                </p>
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                className="rounded-xl border-blue-500/30 text-blue-700 hover:bg-blue-100 dark:text-blue-300 dark:hover:bg-blue-950/50 shrink-0"
+                onClick={() => setReindexDialogOpen(true)}
+                disabled={isReindexing || searchIndex.status === 'indexing' || searchIndex.status === 'creating'}
+              >
+                <RotateCcw className={`h-3.5 w-3.5 mr-2 ${isReindexing ? 'animate-spin' : ''}`} />
+                {isReindexing ? 'Reindexing...' : 'Reindex Now'}
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
       {/* Stats Cards */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
         <Card className="border-border/60 shadow-sm rounded-2xl">

--- a/backend/src/content/docs/concepts/index-fields.md
+++ b/backend/src/content/docs/concepts/index-fields.md
@@ -84,7 +84,7 @@ Does keyword search look at this field's content?
 - **On** for things like `title`, `description`, `brand`, `body` — anything users would type words from.
 - **Off** for things like internal IDs, image URLs, prices.
 
-Searchable fields are run through the index's text analysis (stemming, stop words, lowercasing) so a search for *"running shoes"* matches *"runner shoe"*.
+Searchable fields are run through the index's text analysis (lowercasing, stop words, stemming) so a search for *"jackets"* matches *"jacket"*, and *"the running shoes"* matches *"run shoe"*. Stemming reduces words to a root form, so it handles plurals and verb endings — it is not a thesaurus, and *"runner"* does not reduce to *"run"*. For relationships stemming can't see, use [synonyms](synonyms-and-stop-words).
 
 **Changing this requires a [rebuild](rebuilding-an-index).**
 

--- a/backend/src/content/docs/concepts/rebuilding-an-index.md
+++ b/backend/src/content/docs/concepts/rebuilding-an-index.md
@@ -56,13 +56,15 @@ After changes that require a rebuild, the floating save bar has a **Reindex Now*
 
 ## What happens during a rebuild
 
+- The index is recreated from your current configuration, including its text-analysis settings (language, stop words, synonyms).
 - Every document is re-read from internal storage.
-- Run through the current text-analysis pipeline (language, stop words, synonyms).
 - Re-mapped through your current field mappings.
 - **Fields that are no longer in your configuration are dropped** — this is what actually purges a [field you deleted](index-fields#removing-a-field). Values for it survive in the search engine until this point.
 - Written back to the search index.
 
 Once the rebuild succeeds the "Reindex needed" flag clears.
+
+Recreating the index is why a rebuild is the only way to change analysis: stemming and stop words are baked into the index mapping when it's created, and no search engine lets you change that in place. An index created before language analysis was applied needs one rebuild before searches like "jackets" start matching "jacket" — see [Language](synonyms-and-stop-words#language).
 
 For Semantic / Hybrid indexes, the embeddings are *not* regenerated — only the lexical side is reprocessed. This is fast.
 

--- a/backend/src/content/docs/concepts/synonyms-and-stop-words.md
+++ b/backend/src/content/docs/concepts/synonyms-and-stop-words.md
@@ -66,6 +66,8 @@ That's why searching *"the running shoes"* and *"running shoes"* give the same r
 
 Most of the time you leave the defaults alone. But sometimes you want to **add** to the list — and very occasionally, **remove** from it.
 
+**This setting currently applies to Elasticsearch indexes only.** Azure AI Search indexes fall back to Azure's default analyser and ignore custom stop words entirely — the Custom Stop Words card is hidden when editing an Azure-backed index.
+
 ### When you'd customise stop words
 
 - **Domain-specific filler.** A legal document corpus might want to ignore "whereas", "hereby", "thereof".
@@ -87,34 +89,46 @@ Most of the time you leave the defaults alone. But sometimes you want to **add**
 
 ## Language
 
-The **Language** dropdown on the same tab controls which built-in analyser the index uses. English gets English stop words, English stemming (so "running" → "run"), English-aware tokenisation. French gets French equivalents, and so on.
+The **Language** dropdown on the same tab controls the stemming and stop-word rules the index uses. English gets English stop words and English stemming, so "running" and "run" match each other — and, the one you notice first, "jackets" finds documents that say "jacket". French gets French equivalents, and so on.
+
+Two limits worth knowing:
+
+- **A few languages have stop words but no stemmer** in core Elasticsearch — Thai, Persian, Serbian, and the CJK languages. Those indexes still get lowercasing and stop-word removal; they just don't stem. Polish needs a plugin and gets neither. Picking **Standard** deliberately turns off both.
+- **This setting currently applies to Elasticsearch indexes only.** Azure AI Search indexes fall back to Azure's default analyser, which does not stem.
 
 If your content is multilingual, you have a couple of options:
 
 - **One index per language**, each set to its language. Highest quality, more management.
 - **One index in a multilingual mode** if your search provider supports it (Elasticsearch's `cjk` analyser, Azure Cognitive Search's language detectors). Simpler, slightly lower quality.
 
-Changing the language requires a [rebuild](rebuilding-an-index).
+Changing the language requires a [rebuild](rebuilding-an-index). So does picking up stemming for the first time: an index built before language analysis was applied needs one reindex before "jackets" starts matching "jacket".
+
+### Advanced analyser configuration
+
+The index record carries an `analyzerConfig` field (custom tokenizer, token filters, character filters). **It is not implemented** — nothing reads it, and setting it has no effect. Use the Language, Synonyms and Stop Words settings above, or a per-field analyser override, instead.
 
 ## How synonyms, stop words, and language work together
 
 When a document is indexed:
 
 1. Text is broken into tokens.
-2. Stop words are dropped.
-3. Each remaining token is stemmed using the language's rules.
-4. Synonyms are expanded.
+2. Tokens are lowercased.
+3. Stop words are dropped.
+4. Each remaining token is stemmed using the language's rules.
 5. The result is what gets indexed.
 
 When a user searches:
 
 1. The query is broken into tokens.
-2. Stop words are dropped.
-3. Each remaining token is stemmed.
-4. Synonyms are expanded (or rewritten, for `=>`).
-5. The result is what gets matched against the index.
+2. Tokens are lowercased.
+3. Synonyms are expanded (or rewritten, for `=>`).
+4. Stop words are dropped.
+5. Each remaining token is stemmed.
+6. The result is what gets matched against the index.
 
-Because indexing and searching both go through the same pipeline, anything you change about the pipeline (language, stop words, synonyms) requires existing documents to be re-processed before the change is visible in results.
+Synonyms are expanded on the query side only, and they expand *before* stemming — that's why you write rules in natural form (`bags => handbags`, not `bag => handbag`). Everything after that point is identical on both sides, which is what makes the two halves line up: a document stemmed to `jacket` is found by a query for "jackets", which stems to `jacket` too.
+
+Because indexing and searching go through the same stop-word and stemming steps, anything you change about them (language, stop words, synonyms) requires existing documents to be re-processed before the change is visible in results.
 
 ## Where to go next
 

--- a/backend/src/features/document-indexing/document-indexer.service.ts
+++ b/backend/src/features/document-indexing/document-indexer.service.ts
@@ -29,7 +29,7 @@ import * as fieldsService from '@/features/search-index/search-index-fields.serv
 import * as fieldsRepository from '@/features/search-index/search-index-fields.repository';
 import { generateEmbeddings } from '@/features/ai-service';
 import type { SearchIndexField } from '@/db/schema/search-index-fields.schema';
-import { getProviderSettings, getProviderFieldSettings } from '@/features/search-index/provider-settings.utils';
+import { buildIndexSettingsContext } from '@/features/search-index/provider-settings.utils';
 import { getEmbeddingText } from './embedding-text';
 
 const logger = createLogger('document-indexer');
@@ -398,7 +398,18 @@ async function ensureIndex(
     fields: SearchIndexField[],
     embeddingConfig?: EmbeddingConfig,
     searchProviderType?: SearchProviderType,
-    indexRecord?: { providerSettings?: Record<string, unknown> | null; numberOfShards?: number; numberOfReplicas?: number; refreshInterval?: string }
+    indexRecord?: {
+        providerSettings?: Record<string, unknown> | null;
+        numberOfShards?: number;
+        numberOfReplicas?: number;
+        refreshInterval?: string;
+        // Text analysis — an index created here must get the same analyzers as one
+        // created by an explicit reindex, or search behaves differently depending
+        // on how the index happened to come into existence.
+        language?: string | null;
+        synonyms?: unknown;
+        stopWords?: unknown;
+    }
 ): Promise<{ success: boolean; error?: string; warning?: string }> {
     const provider = getSearchEngineProvider(searchProviderType);
     const exists = await provider.indexExists(indexName);
@@ -489,23 +500,16 @@ async function ensureIndex(
         });
     }
 
-    // Resolve provider settings from the index record (backward-compat aware)
-    const providerSettings = indexRecord
-        ? getProviderSettings(indexRecord as Parameters<typeof getProviderSettings>[0])
-        : {};
-
-    // Let the provider build its own native index settings
-    const indexConfig = provider.buildIndexSettings({
-        fields: fields.map(f => ({
-            fieldName: f.fieldName,
-            fieldType: f.fieldType,
-            isSearchable: f.isSearchable,
-            isFacetable: f.isFacetable,
-            providerFieldSettings: getProviderFieldSettings(f),
-        })),
-        providerSettings,
-        embeddingConfig: embeddingBuildConfig,
-    });
+    // Let the provider build its own native index settings. Same helper the
+    // reindex and recreate-empty paths use, so all three produce identical
+    // mappings and text analysis for the same index record.
+    const indexConfig = provider.buildIndexSettings(
+        buildIndexSettingsContext(
+            (indexRecord ?? {}) as Parameters<typeof buildIndexSettingsContext>[0],
+            fields,
+            embeddingBuildConfig
+        )
+    );
 
     return await provider.createIndex(indexName, indexConfig);
 }

--- a/backend/src/features/search-index/index.ts
+++ b/backend/src/features/search-index/index.ts
@@ -185,6 +185,7 @@ export {
     ES_LANGUAGES,
     REFRESH_INTERVALS,
     FIELDS_REQUIRING_REINDEX,
+    getReindexFieldsForProvider,
     fieldRequiresReindex,
     updatesRequireReindex,
 } from './search-index.types';

--- a/backend/src/features/search-index/provider-settings.utils.ts
+++ b/backend/src/features/search-index/provider-settings.utils.ts
@@ -7,7 +7,14 @@
  * from search indexes and fields. During the migration period, these
  * read from the new providerSettings JSON column first, falling back
  * to the legacy individual columns for pre-migration data.
+ *
+ * Also assembles the full IndexSettingsBuildContext, so every code path that
+ * creates a provider index derives it the same way.
  */
+
+// `import type` only — this module is erased at runtime, so it does not pull in
+// the 'server-only' guard that search-engine-provider.interface.ts carries.
+import type { IndexSettingsBuildContext } from '@/features/search/providers/search-engine-provider.interface';
 
 /**
  * Shape of the index properties we actually read.
@@ -18,6 +25,26 @@ interface IndexWithProviderSettings {
     numberOfShards: number;
     numberOfReplicas: number;
     refreshInterval: string;
+}
+
+/**
+ * Index properties needed to build a full IndexSettingsBuildContext:
+ * provider settings plus the text-analysis configuration.
+ */
+interface IndexForSettingsContext extends IndexWithProviderSettings {
+    language?: string | null;
+    synonyms?: unknown;
+    stopWords?: unknown;
+}
+
+/**
+ * Field properties needed to build a full IndexSettingsBuildContext.
+ */
+interface FieldForSettingsContext extends FieldWithProviderSettings {
+    fieldName: string;
+    fieldType: string;
+    isSearchable: boolean;
+    isFacetable: boolean;
 }
 
 /**
@@ -78,5 +105,48 @@ export function getProviderFieldSettings(
     return {
         isAutocomplete: field.isAutocomplete,
         customAnalyzer: field.customAnalyzer,
+    };
+}
+
+/**
+ * Normalize a JSON column that should hold a list of strings.
+ * Drizzle types these as string[], but older rows can hold null or junk.
+ */
+function toStringList(value: unknown): string[] {
+    if (!Array.isArray(value)) return [];
+    return value
+        .filter((v): v is string => typeof v === 'string')
+        .map(v => v.trim())
+        .filter(v => v.length > 0);
+}
+
+/**
+ * Assemble the context a provider needs to build its native index settings.
+ *
+ * Every path that creates a provider index goes through here — reindex,
+ * recreate-empty, and the auto-create on first document upload — so an index
+ * gets the same mappings and the same text analysis regardless of how it came
+ * into existence. Previously each call site built this object by hand and they
+ * had drifted: the auto-create path passed no synonyms at all.
+ */
+export function buildIndexSettingsContext(
+    index: IndexForSettingsContext,
+    fields: FieldForSettingsContext[],
+    embeddingConfig?: { fieldName: string; dimensions: number; similarity: string }
+): IndexSettingsBuildContext {
+    return {
+        fields: fields.map(f => ({
+            fieldName: f.fieldName,
+            fieldType: f.fieldType,
+            isSearchable: f.isSearchable,
+            isFacetable: f.isFacetable,
+            isAutocomplete: f.isAutocomplete,
+            providerFieldSettings: getProviderFieldSettings(f),
+        })),
+        providerSettings: getProviderSettings(index),
+        embeddingConfig,
+        synonyms: toStringList(index.synonyms),
+        language: index.language ?? 'english',
+        stopWords: toStringList(index.stopWords),
     };
 }

--- a/backend/src/features/search-index/search-index.service.ts
+++ b/backend/src/features/search-index/search-index.service.ts
@@ -40,11 +40,11 @@ import type {
  ChangeAIConfigDTO } from './search-index.validation';
 import type { SearchIndex, NewSearchIndex } from '@/db/schema/search-index.schema';
 import type { SearchIndexField } from '@/db/schema/search-index-fields.schema';
-import { requiresAIConfiguration, SYSTEM_FIELD_MAPPING_CONFIGS , SearchType } from '@/shared/constants/search-index.constants';
+import { requiresAIConfiguration, SYSTEM_FIELD_MAPPING_CONFIGS , SearchType, getReindexFieldsForProvider } from '@/shared/constants/search-index.constants';
 import * as fieldsRepository from './search-index-fields.repository';
 import { getSearchEngineProvider, type SearchProviderType } from '@/features/search/providers';
 import { selectedSearchProvider } from '@/config/search-provider.config';
-import { getProviderSettings, getProviderFieldSettings } from './provider-settings.utils';
+import { buildIndexSettingsContext } from './provider-settings.utils';
 
 const logger = createLogger('search-index-service');
 
@@ -427,9 +427,25 @@ export async function updateSearchIndex(
         // Update in database
         await repository.updateSearchIndex(id, updateData);
 
-        // Analyzer-affecting settings (synonyms, stop words, analyzer config) can't be
-        // changed in place on the provider index — they take effect on the next reindex.
-        // The stored config is the source of truth; reindexing rebuilds the index from it.
+        // Analyzer-affecting settings (language, synonyms, stop words, analyzer config)
+        // can't be changed in place on the provider index — they take effect on the next
+        // reindex. The stored config is the source of truth; reindexing rebuilds the
+        // index from it. Flag that so the UI's "reindex needed" badge — which reads the
+        // persisted flag, not the edit form's dirty state — reflects reality for anyone
+        // who opens the index later.
+        const reindexFields = getReindexFieldsForProvider(existing.searchProvider);
+        const changedReindexFields = reindexFields.filter(field => {
+            if (updateData[field] === undefined) return false;
+            return JSON.stringify(updateData[field]) !== JSON.stringify(existing[field]);
+        });
+
+        if (changedReindexFields.length > 0) {
+            await repository.incrementMappingVersion(id);
+            logger.info('Text analysis settings changed — index requires reindex', {
+                indexId: id,
+                changedFields: changedReindexFields,
+            });
+        }
 
         // Clear caches
         await clearIndexCache(id, existing.name);
@@ -1018,19 +1034,9 @@ export async function triggerReindex(
         }
 
         // Let the provider build its own native index settings
-        const indexConfig = provider.buildIndexSettings({
-            fields: fields.map(f => ({
-                fieldName: f.fieldName,
-                fieldType: f.fieldType,
-                isSearchable: f.isSearchable,
-                isFacetable: f.isFacetable,
-                isAutocomplete: f.isAutocomplete,
-                providerFieldSettings: getProviderFieldSettings(f),
-            })),
-            providerSettings: getProviderSettings(searchIndex),
-            embeddingConfig,
-            synonyms: Array.isArray(searchIndex.synonyms) ? (searchIndex.synonyms as string[]) : [],
-        });
+        const indexConfig = provider.buildIndexSettings(
+            buildIndexSettingsContext(searchIndex, fields, embeddingConfig)
+        );
 
         logger.info('Built index settings via provider', {
             indexName,
@@ -1207,19 +1213,9 @@ export async function recreateEmptyIndex(
         }
 
         // Build provider-native index settings from DB definitions
-        const indexConfig = provider.buildIndexSettings({
-            fields: fields.map(f => ({
-                fieldName: f.fieldName,
-                fieldType: f.fieldType,
-                isSearchable: f.isSearchable,
-                isFacetable: f.isFacetable,
-                isAutocomplete: f.isAutocomplete,
-                providerFieldSettings: getProviderFieldSettings(f),
-            })),
-            providerSettings: getProviderSettings(searchIndex),
-            embeddingConfig,
-            synonyms: Array.isArray(searchIndex.synonyms) ? (searchIndex.synonyms as string[]) : [],
-        });
+        const indexConfig = provider.buildIndexSettings(
+            buildIndexSettingsContext(searchIndex, fields, embeddingConfig)
+        );
 
         // Create the index
         const createResult = await provider.createIndex(indexName, indexConfig);
@@ -1232,6 +1228,10 @@ export async function recreateEmptyIndex(
             documentCount: 0,
         });
         await repository.updateSearchIndexStatus(searchIndexId, 'ready');
+
+        // The index was just rebuilt from the current DB mappings and text
+        // analysis settings, so it's structurally in sync even though empty.
+        await repository.markMappingSynced(searchIndexId);
 
         // Clear caches so UI gets fresh data
         await clearIndexCache(searchIndexId, indexName);

--- a/backend/src/features/search-index/search-index.types.ts
+++ b/backend/src/features/search-index/search-index.types.ts
@@ -89,6 +89,7 @@ export {
     ES_LANGUAGES,
     REFRESH_INTERVALS,
     FIELDS_REQUIRING_REINDEX,
+    getReindexFieldsForProvider,
     fieldRequiresReindex,
     updatesRequireReindex,
 } from '@/shared/constants/search-index.constants';

--- a/backend/src/features/search/providers/elasticsearch/elasticsearch-engine.provider.test.ts
+++ b/backend/src/features/search/providers/elasticsearch/elasticsearch-engine.provider.test.ts
@@ -1,0 +1,239 @@
+// src/features/search/providers/elasticsearch/elasticsearch-engine.provider.test.ts
+
+/**
+ * Elasticsearch index settings builder.
+ *
+ * The regression these tests exist for: the index's `language` and `stopWords`
+ * were stored, editable in the UI and documented as working, but never reached
+ * Elasticsearch. Every searchable text field was created as bare
+ * `{ type: 'text' }`, so ES applied the `standard` analyzer and did no stemming
+ * — a search for "jackets" found nothing in an index holding "jacket".
+ *
+ * The other half of the bug is symmetry: the index-time and search-time
+ * analyzers must apply the same stop/stemmer filters, or a stemmed index
+ * becomes unreachable from an unstemmed query. Anything below asserting that
+ * both chains end in the same filters is guarding that.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { ElasticsearchEngineProvider } from './elasticsearch-engine.provider';
+import type { IndexSettingsBuildContext } from '../search-engine-provider.interface';
+
+const provider = new ElasticsearchEngineProvider();
+
+type Analysis = {
+    analyzer: Record<string, { type: string; tokenizer: string; filter: string[] }>;
+    filter?: Record<string, Record<string, unknown>>;
+    tokenizer?: Record<string, Record<string, unknown>>;
+};
+
+/** A text field plus whatever context overrides a test cares about. */
+function build(overrides: Partial<IndexSettingsBuildContext> = {}) {
+    const result = provider.buildIndexSettings({
+        fields: [
+            {
+                fieldName: 'careInstructions',
+                fieldType: 'text',
+                isSearchable: true,
+                isFacetable: false,
+                providerFieldSettings: {},
+            },
+        ],
+        providerSettings: {},
+        ...overrides,
+    });
+
+    return {
+        analysis: (result.settings as { analysis: Analysis }).analysis,
+        properties: (result.mappings as { properties: Record<string, Record<string, unknown>> }).properties,
+        settings: result.settings as Record<string, unknown>,
+    };
+}
+
+describe('text analysis', () => {
+    it('stems with the index language and attaches both analyzers to text fields', () => {
+        const { analysis, properties } = build({ language: 'english' });
+
+        expect(analysis.filter?.interakt_stemmer).toEqual({ type: 'stemmer', language: 'english' });
+        expect(properties.careInstructions).toEqual({
+            type: 'text',
+            analyzer: 'interakt_text',
+            search_analyzer: 'interakt_text_search',
+        });
+    });
+
+    it('uses the language stop word list', () => {
+        const { analysis } = build({ language: 'danish' });
+
+        expect(analysis.filter?.interakt_stop).toEqual({ type: 'stop', stopwords: ['_danish_'] });
+        expect(analysis.filter?.interakt_stemmer).toEqual({ type: 'stemmer', language: 'danish' });
+    });
+
+    it('merges custom stop words on top of the language list', () => {
+        const { analysis } = build({ language: 'english', stopWords: ['premium', 'exclusive'] });
+
+        expect(analysis.filter?.interakt_stop).toEqual({
+            type: 'stop',
+            stopwords: ['_english_', 'premium', 'exclusive'],
+        });
+    });
+
+    it('defaults to english when no language is given', () => {
+        const { analysis } = build();
+
+        expect(analysis.filter?.interakt_stemmer).toEqual({ type: 'stemmer', language: 'english' });
+    });
+
+    it('omits the stemmer for languages core ES has none for', () => {
+        const { analysis, properties } = build({ language: 'thai' });
+
+        expect(analysis.filter?.interakt_stemmer).toBeUndefined();
+        expect(analysis.filter?.interakt_stop).toEqual({ type: 'stop', stopwords: ['_thai_'] });
+        // Still a valid, referenceable analyzer pair.
+        expect(analysis.analyzer.interakt_text.filter).toEqual(['lowercase', 'interakt_stop']);
+        expect(properties.careInstructions.analyzer).toBe('interakt_text');
+    });
+
+    it('degrades to lowercase-only for language "standard"', () => {
+        const { analysis } = build({ language: 'standard' });
+
+        expect(analysis.filter).toBeUndefined();
+        expect(analysis.analyzer.interakt_text.filter).toEqual(['lowercase']);
+        expect(analysis.analyzer.interakt_text_search.filter).toEqual(['lowercase']);
+    });
+
+    it('falls back to lowercase-only for an unknown language rather than emitting an invalid filter', () => {
+        // An invalid stemmer.language or unknown _lang_ reference makes
+        // indices.create fail outright, so a legacy value must degrade quietly.
+        const { analysis } = build({ language: 'klingon' });
+
+        expect(analysis.filter).toBeUndefined();
+        expect(analysis.analyzer.interakt_text.filter).toEqual(['lowercase']);
+    });
+});
+
+describe('synonyms', () => {
+    it('expands synonyms at search time only, over the same stop/stemmer chain', () => {
+        const { analysis } = build({
+            language: 'english',
+            synonyms: ['bags => handbags', 'tv, television'],
+        });
+
+        expect(analysis.filter?.interakt_synonyms).toEqual({
+            type: 'synonym_graph',
+            synonyms: ['bags => handbags', 'tv, television'],
+            lenient: true,
+        });
+
+        // Synonyms expand before stop/stemming, so rules stay writable in
+        // natural form while both sides still end up stemmed.
+        expect(analysis.analyzer.interakt_text.filter).toEqual([
+            'lowercase', 'interakt_stop', 'interakt_stemmer',
+        ]);
+        expect(analysis.analyzer.interakt_text_search.filter).toEqual([
+            'lowercase', 'interakt_synonyms', 'interakt_stop', 'interakt_stemmer',
+        ]);
+    });
+
+    it('keeps the two chains symmetric apart from the synonym filter', () => {
+        for (const synonyms of [[], ['tv, television']]) {
+            const { analysis } = build({ language: 'german', synonyms });
+            const indexChain = analysis.analyzer.interakt_text.filter;
+            const searchChain = analysis.analyzer.interakt_text_search.filter;
+
+            expect(searchChain.filter(f => f !== 'interakt_synonyms')).toEqual(indexChain);
+        }
+    });
+
+    it('ignores blank synonym rules', () => {
+        const { analysis } = build({ language: 'english', synonyms: ['  ', ''] });
+
+        expect(analysis.filter?.interakt_synonyms).toBeUndefined();
+        expect(analysis.analyzer.interakt_text_search.filter).not.toContain('interakt_synonyms');
+    });
+});
+
+describe('per-field analyzer precedence', () => {
+    it('leaves autocomplete fields on the edge-ngram pair and keeps its tokenizer', () => {
+        const result = provider.buildIndexSettings({
+            fields: [
+                {
+                    fieldName: 'title',
+                    fieldType: 'text',
+                    isSearchable: true,
+                    providerFieldSettings: { isAutocomplete: true },
+                },
+            ],
+            providerSettings: {},
+            language: 'english',
+        });
+
+        const analysis = (result.settings as { analysis: Analysis }).analysis;
+        const properties = (result.mappings as { properties: Record<string, Record<string, unknown>> }).properties;
+
+        expect(properties.title).toEqual({
+            type: 'text',
+            analyzer: 'autocomplete',
+            search_analyzer: 'autocomplete_search',
+        });
+        // The language pair is still defined alongside, and merging it must not
+        // drop the edge-ngram tokenizer the autocomplete analyzer depends on.
+        expect(analysis.analyzer.autocomplete).toBeDefined();
+        expect(analysis.analyzer.interakt_text).toBeDefined();
+        expect(analysis.tokenizer?.autocomplete_tokenizer).toMatchObject({ type: 'edge_ngram' });
+    });
+
+    it('lets an explicit customAnalyzer override the language pair', () => {
+        const result = provider.buildIndexSettings({
+            fields: [
+                {
+                    fieldName: 'sku',
+                    fieldType: 'text',
+                    isSearchable: true,
+                    providerFieldSettings: { customAnalyzer: 'keyword' },
+                },
+            ],
+            providerSettings: {},
+            language: 'english',
+        });
+
+        const properties = (result.mappings as { properties: Record<string, Record<string, unknown>> }).properties;
+
+        expect(properties.sku).toEqual({ type: 'text', analyzer: 'keyword' });
+    });
+
+    it('leaves keyword fields unanalyzed and keeps the facet subfield on text', () => {
+        const result = provider.buildIndexSettings({
+            fields: [
+                { fieldName: 'brand', fieldType: 'keyword', isFacetable: true, providerFieldSettings: {} },
+                { fieldName: 'category', fieldType: 'text', isSearchable: true, isFacetable: true, providerFieldSettings: {} },
+            ],
+            providerSettings: {},
+            language: 'english',
+        });
+
+        const properties = (result.mappings as { properties: Record<string, Record<string, unknown>> }).properties;
+
+        expect(properties.brand).toEqual({ type: 'keyword' });
+        expect(properties.category).toEqual({
+            type: 'text',
+            analyzer: 'interakt_text',
+            search_analyzer: 'interakt_text_search',
+            fields: { keyword: { type: 'keyword', ignore_above: 256 } },
+        });
+    });
+});
+
+describe('provider settings passthrough', () => {
+    it('still maps shards, replicas and refresh interval alongside the analysis block', () => {
+        const { settings, analysis } = build({
+            language: 'english',
+            providerSettings: { numberOfShards: 3, numberOfReplicas: 2, refreshInterval: '30s' },
+        });
+
+        expect(settings.number_of_shards).toBe(3);
+        expect(settings.number_of_replicas).toBe(2);
+        expect(settings.refresh_interval).toBe('30s');
+        expect(analysis.analyzer.interakt_text).toBeDefined();
+    });
+});

--- a/backend/src/features/search/providers/elasticsearch/elasticsearch-engine.provider.ts
+++ b/backend/src/features/search/providers/elasticsearch/elasticsearch-engine.provider.ts
@@ -38,7 +38,15 @@ import {
 import { createLogger } from '@/shared/logger/logger';
 import { ElasticsearchFieldMapper } from './elasticsearch-field-mapper';
 import { ELASTICSEARCH_CAPABILITIES } from './elasticsearch-capabilities';
-import { AUTOCOMPLETE_ANALYZER_SETTINGS } from './elasticsearch.constants';
+import {
+    AUTOCOMPLETE_ANALYZER_SETTINGS,
+    getLanguageAnalysis,
+    INTERAKT_STOP_FILTER,
+    INTERAKT_STEMMER_FILTER,
+    INTERAKT_SYNONYM_FILTER,
+    INTERAKT_TEXT_ANALYZER,
+    INTERAKT_TEXT_SEARCH_ANALYZER,
+} from './elasticsearch.constants';
 import { registerProviderClass } from '../search-engine-provider.factory';
 import { buildFilterQuery } from './query-builders/filter.builder';
 import type { ProviderCapabilities } from '../provider-capabilities';
@@ -254,6 +262,7 @@ export class ElasticsearchEngineProvider implements SearchEngineProvider {
      *
      * Handles:
      * - Field type mapping (text, keyword, integer, etc.)
+     * - Text analysis: language stemmer, stop words, synonyms
      * - Autocomplete analyzer configuration (edge_ngram)
      * - Vector/embedding field (dense_vector)
      * - Index-level settings (shards, replicas, refresh interval)
@@ -292,45 +301,87 @@ export class ElasticsearchEngineProvider implements SearchEngineProvider {
             Object.assign(indexSettings, AUTOCOMPLETE_ANALYZER_SETTINGS);
         }
 
-        // Apply synonyms as a search-time analyzer. We define a dedicated synonym
-        // search analyzer and attach it as `search_analyzer` to searchable text fields,
-        // so equivalent terms expand at query time. Synonyms only apply to analyzed
-        // `text` fields — `keyword` fields (exact-match facets) are intentionally left
-        // alone. Autocomplete fields keep their own analyzer and are not touched, so
-        // type-ahead behavior is unchanged. We also register `default_search` as a
-        // fallback for any text field that has no explicit search analyzer.
-        // Existing analysis is spread into fresh objects so the shared autocomplete
-        // constant is never mutated.
-        const synonymRules = (context.synonyms ?? []).filter(r => typeof r === 'string' && r.trim());
-        if (synonymRules.length > 0) {
-            const synonymAnalyzer = { type: 'custom', tokenizer: 'standard', filter: ['lowercase', 'interakt_synonyms'] };
-            const existing = (indexSettings.analysis as Record<string, unknown> | undefined) ?? {};
-            indexSettings.analysis = {
-                ...existing,
-                filter: {
-                    ...(existing.filter as Record<string, unknown> | undefined),
-                    interakt_synonyms: { type: 'synonym_graph', synonyms: synonymRules, lenient: true },
-                },
-                analyzer: {
-                    ...(existing.analyzer as Record<string, unknown> | undefined),
-                    interakt_synonym_search: synonymAnalyzer,
-                    default_search: synonymAnalyzer,
-                },
-            };
+        // Build the text analysis pair from the index's language, stop words and
+        // synonyms. `interakt_text` runs at index time, `interakt_text_search` at
+        // search time; they share the same tokenizer and the same stop/stemmer
+        // filters, and the search analyzer additionally expands synonyms.
+        //
+        // The symmetry is the point. Stemming only helps if both sides do it: an
+        // index holding the token `jacket` is unreachable from a query analyzed to
+        // `jackets`. That is exactly what the previous synonym-only search analyzer
+        // would have caused once stemming was introduced.
+        //
+        // The pair is always defined — even for language 'standard', where it
+        // degrades to lowercase-only — so mapFieldTypeToES can reference the names
+        // unconditionally. Existing analysis is spread into fresh objects so the
+        // shared autocomplete constant is never mutated.
+        const { stopwords: builtInStopWords, stemmer } = getLanguageAnalysis(context.language);
+        const customStopWords = (context.stopWords ?? [])
+            .filter((w): w is string => typeof w === 'string')
+            .map(w => w.trim())
+            .filter(w => w.length > 0);
+        const synonymRules = (context.synonyms ?? [])
+            .filter((r): r is string => typeof r === 'string')
+            .map(r => r.trim())
+            .filter(r => r.length > 0);
 
-            // Attach to searchable text fields, skipping autocomplete fields (which keep
-            // their own search_analyzer) and keyword fields (not analyzed).
-            const autocompleteNames = new Set(
-                context.fields.filter(f => f.providerFieldSettings?.isAutocomplete === true).map(f => f.fieldName)
-            );
-            for (const f of context.fields) {
-                if (!f.isSearchable || autocompleteNames.has(f.fieldName)) continue;
-                const prop = properties[f.fieldName] as Record<string, unknown> | undefined;
-                if (prop && prop.type === 'text' && prop.search_analyzer === undefined) {
-                    prop.search_analyzer = 'interakt_synonym_search';
-                }
-            }
+        const analysisFilters: Record<string, unknown> = {};
+
+        // A single stop filter carrying the language's predefined list plus any
+        // custom words — ES accepts `_english_` and literal words in one array.
+        const stopWordList = [
+            ...(builtInStopWords ? [builtInStopWords] : []),
+            ...customStopWords,
+        ];
+        if (stopWordList.length > 0) {
+            analysisFilters[INTERAKT_STOP_FILTER] = { type: 'stop', stopwords: stopWordList };
         }
+        if (stemmer) {
+            analysisFilters[INTERAKT_STEMMER_FILTER] = { type: 'stemmer', language: stemmer };
+        }
+        if (synonymRules.length > 0) {
+            analysisFilters[INTERAKT_SYNONYM_FILTER] = {
+                type: 'synonym_graph',
+                synonyms: synonymRules,
+                lenient: true,
+            };
+        }
+
+        // Synonyms expand before stop/stemming so rules stay writable in natural
+        // form ("bags => handbags") while both sides still end up stemmed.
+        const languageFilters = [
+            ...(analysisFilters[INTERAKT_STOP_FILTER] ? [INTERAKT_STOP_FILTER] : []),
+            ...(analysisFilters[INTERAKT_STEMMER_FILTER] ? [INTERAKT_STEMMER_FILTER] : []),
+        ];
+        const existingAnalysis = (indexSettings.analysis as Record<string, unknown> | undefined) ?? {};
+        indexSettings.analysis = {
+            ...existingAnalysis,
+            ...(Object.keys(analysisFilters).length > 0
+                ? {
+                    filter: {
+                        ...(existingAnalysis.filter as Record<string, unknown> | undefined),
+                        ...analysisFilters,
+                    },
+                }
+                : {}),
+            analyzer: {
+                ...(existingAnalysis.analyzer as Record<string, unknown> | undefined),
+                [INTERAKT_TEXT_ANALYZER]: {
+                    type: 'custom',
+                    tokenizer: 'standard',
+                    filter: ['lowercase', ...languageFilters],
+                },
+                [INTERAKT_TEXT_SEARCH_ANALYZER]: {
+                    type: 'custom',
+                    tokenizer: 'standard',
+                    filter: [
+                        'lowercase',
+                        ...(analysisFilters[INTERAKT_SYNONYM_FILTER] ? [INTERAKT_SYNONYM_FILTER] : []),
+                        ...languageFilters,
+                    ],
+                },
+            },
+        };
 
         // Extract ES-specific settings from providerSettings
         const ps = context.providerSettings;

--- a/backend/src/features/search/providers/elasticsearch/elasticsearch-field-mapping.ts
+++ b/backend/src/features/search/providers/elasticsearch/elasticsearch-field-mapping.ts
@@ -9,6 +9,7 @@
  */
 
 import type { SearchIndexField } from '@/db/schema/search-index-fields.schema';
+import { INTERAKT_TEXT_ANALYZER, INTERAKT_TEXT_SEARCH_ANALYZER } from './elasticsearch.constants';
 
 /**
  * Map our field types to Elasticsearch types
@@ -31,8 +32,18 @@ export function mapFieldTypeToES(field: SearchIndexField): Record<string, unknow
                 mapping.analyzer = 'autocomplete';
                 mapping.search_analyzer = 'autocomplete_search';
             } else if (customAnalyzer) {
-                // Apply custom analyzer if specified
+                // Apply custom analyzer if specified. No search_analyzer, so ES
+                // uses the same analyzer on both sides — an explicit per-field
+                // override wins over the index's language analysis.
                 mapping.analyzer = customAnalyzer;
+            } else {
+                // Default: the analyzer pair built from the index's language and
+                // stop words. Without this the field falls back to ES `standard`,
+                // which does not stem — a search for "jackets" would then miss a
+                // document containing "jacket". buildIndexSettings always defines
+                // both analyzers, so these names are safe to reference here.
+                mapping.analyzer = INTERAKT_TEXT_ANALYZER;
+                mapping.search_analyzer = INTERAKT_TEXT_SEARCH_ANALYZER;
             }
 
             // Add keyword subfield for faceting/sorting if field is facetable

--- a/backend/src/features/search/providers/elasticsearch/elasticsearch.constants.ts
+++ b/backend/src/features/search/providers/elasticsearch/elasticsearch.constants.ts
@@ -166,6 +166,104 @@ export const ES_LANGUAGES = [
 export type ESLanguage = typeof ES_LANGUAGES[number]['value'];
 
 // ============================================================================
+// LANGUAGE TEXT ANALYSIS
+// Maps each ES_LANGUAGES value to the ES analysis primitives it can use.
+// ============================================================================
+
+/**
+ * Names of the analyzer pair built from the index's language + stop words.
+ *
+ * `interakt_text` is the index-time analyzer, `interakt_text_search` the
+ * search-time one. They share the same tokenizer and the same stop/stemmer
+ * filters; the search analyzer additionally expands synonyms. Keeping the two
+ * chains symmetric is what makes a stemmed index searchable — an unstemmed
+ * search analyzer over a stemmed index matches nothing.
+ *
+ * Exported so the field mapper and the settings builder cannot drift apart.
+ */
+export const INTERAKT_TEXT_ANALYZER = 'interakt_text';
+export const INTERAKT_TEXT_SEARCH_ANALYZER = 'interakt_text_search';
+
+/** Filter names used inside the analyzer pair. */
+export const INTERAKT_STOP_FILTER = 'interakt_stop';
+export const INTERAKT_STEMMER_FILTER = 'interakt_stemmer';
+export const INTERAKT_SYNONYM_FILTER = 'interakt_synonyms';
+
+/**
+ * ES analysis primitives available per language.
+ *
+ * - `stopwords` — a predefined stop word list reference (`_english_`, ...).
+ * - `stemmer` — a `language` value accepted by the `stemmer` token filter.
+ *
+ * A key is omitted when core Elasticsearch has no such option for the language.
+ * That matters: an invalid `stemmer.language` or an unknown `_lang_` stop word
+ * reference makes `indices.create` fail outright, so guessing is worse than
+ * leaving the filter out. Languages absent from this map fall back to `{}`,
+ * i.e. lowercase-only analysis — the behaviour before this map existed.
+ */
+export const ES_LANGUAGE_ANALYSIS: Record<string, { stopwords?: string; stemmer?: string }> = {
+    arabic: { stopwords: '_arabic_', stemmer: 'arabic' },
+    armenian: { stopwords: '_armenian_', stemmer: 'armenian' },
+    basque: { stopwords: '_basque_', stemmer: 'basque' },
+    bengali: { stopwords: '_bengali_', stemmer: 'bengali' },
+    brazilian: { stopwords: '_brazilian_', stemmer: 'brazilian' },
+    bulgarian: { stopwords: '_bulgarian_', stemmer: 'bulgarian' },
+    catalan: { stopwords: '_catalan_', stemmer: 'catalan' },
+    czech: { stopwords: '_czech_', stemmer: 'czech' },
+    danish: { stopwords: '_danish_', stemmer: 'danish' },
+    dutch: { stopwords: '_dutch_', stemmer: 'dutch' },
+    english: { stopwords: '_english_', stemmer: 'english' },
+    estonian: { stopwords: '_estonian_', stemmer: 'estonian' },
+    finnish: { stopwords: '_finnish_', stemmer: 'finnish' },
+    french: { stopwords: '_french_', stemmer: 'french' },
+    galician: { stopwords: '_galician_', stemmer: 'galician' },
+    german: { stopwords: '_german_', stemmer: 'german' },
+    greek: { stopwords: '_greek_', stemmer: 'greek' },
+    hindi: { stopwords: '_hindi_', stemmer: 'hindi' },
+    hungarian: { stopwords: '_hungarian_', stemmer: 'hungarian' },
+    indonesian: { stopwords: '_indonesian_', stemmer: 'indonesian' },
+    irish: { stopwords: '_irish_', stemmer: 'irish' },
+    italian: { stopwords: '_italian_', stemmer: 'italian' },
+    latvian: { stopwords: '_latvian_', stemmer: 'latvian' },
+    lithuanian: { stopwords: '_lithuanian_', stemmer: 'lithuanian' },
+    norwegian: { stopwords: '_norwegian_', stemmer: 'norwegian' },
+    portuguese: { stopwords: '_portuguese_', stemmer: 'portuguese' },
+    romanian: { stopwords: '_romanian_', stemmer: 'romanian' },
+    russian: { stopwords: '_russian_', stemmer: 'russian' },
+    sorani: { stopwords: '_sorani_', stemmer: 'sorani' },
+    spanish: { stopwords: '_spanish_', stemmer: 'spanish' },
+    swedish: { stopwords: '_swedish_', stemmer: 'swedish' },
+    turkish: { stopwords: '_turkish_', stemmer: 'turkish' },
+
+    // Stop words only — core ES ships no stemmer for these.
+    cjk: { stopwords: '_cjk_' },
+    persian: { stopwords: '_persian_' },
+    serbian: { stopwords: '_serbian_' },
+    thai: { stopwords: '_thai_' },
+
+    // Chinese/Japanese/Korean have no dedicated core analysis; the CJK stop word
+    // list is the closest core equivalent. Proper support needs a plugin
+    // (analysis-smartcn, analysis-kuromoji, analysis-nori).
+    chinese: { stopwords: '_cjk_' },
+    japanese: { stopwords: '_cjk_' },
+    korean: { stopwords: '_cjk_' },
+
+    // Polish needs the analysis-stempel plugin — nothing in core to reference.
+    polish: {},
+
+    // Explicitly "no language-specific processing".
+    standard: {},
+};
+
+/**
+ * Look up the analysis primitives for a language, tolerating unknown values.
+ */
+export function getLanguageAnalysis(language?: string | null): { stopwords?: string; stemmer?: string } {
+    if (!language) return ES_LANGUAGE_ANALYSIS.english;
+    return ES_LANGUAGE_ANALYSIS[language] ?? {};
+}
+
+// ============================================================================
 // REFRESH INTERVAL OPTIONS
 // Common refresh interval values for Elasticsearch
 // ============================================================================

--- a/backend/src/features/search/providers/search-engine-provider.interface.ts
+++ b/backend/src/features/search/providers/search-engine-provider.interface.ts
@@ -85,6 +85,17 @@ export interface IndexSettingsBuildContext {
      * maps these into its native mechanism (Azure synonym map, ES synonym filter).
      */
     synonyms?: string[];
+    /**
+     * Index language for text analysis (see ES_LANGUAGES / AZURE_LANGUAGES).
+     * Drives stemming and the built-in stop word list, so a search for
+     * "jackets" matches a document containing "jacket". Defaults to 'english'.
+     */
+    language?: string;
+    /**
+     * Custom stop words, added on top of the language's built-in list.
+     * Words so common in this corpus that matching them carries no signal.
+     */
+    stopWords?: string[];
 }
 
 /**

--- a/backend/src/shared/constants/search-index.constants.ts
+++ b/backend/src/shared/constants/search-index.constants.ts
@@ -889,7 +889,6 @@ export const FIELDS_REQUIRING_REINDEX = [
     'language',
     'synonyms',
     'stopWords',
-    'analyzerConfig',
 ] as const;
 
 /**
@@ -903,6 +902,17 @@ export const FIELD_SETTINGS_REQUIRING_REINDEX = [
 ] as const;
 
 export type FieldRequiringReindex = typeof FIELDS_REQUIRING_REINDEX[number];
+
+/**
+ * Index-level fields that require reindex when changed, scoped to what the
+ * given search provider actually consumes. Language and stop words only
+ * affect Elasticsearch's analyzer chain today — Azure AI Search ignores them
+ * and only reads synonyms — so flagging them as reindex-worthy on Azure would
+ * be a false positive.
+ */
+export function getReindexFieldsForProvider(searchProvider: string): readonly FieldRequiringReindex[] {
+    return searchProvider === 'elasticsearch' ? FIELDS_REQUIRING_REINDEX : ['synonyms'];
+}
 
 /**
  * Check if updating a field requires reindexing

--- a/backend/src/shared/constants/search-index.constants.ts
+++ b/backend/src/shared/constants/search-index.constants.ts
@@ -910,7 +910,7 @@ export type FieldRequiringReindex = typeof FIELDS_REQUIRING_REINDEX[number];
  * and only reads synonyms — so flagging them as reindex-worthy on Azure would
  * be a false positive.
  */
-export function getReindexFieldsForProvider(searchProvider: string): readonly FieldRequiringReindex[] {
+export function getReindexFieldsForProvider(searchProvider: string | undefined): readonly FieldRequiringReindex[] {
     return searchProvider === 'elasticsearch' ? FIELDS_REQUIRING_REINDEX : ['synonyms'];
 }
 


### PR DESCRIPTION
- Azure's provider only ever reads `context.synonyms`, so flagging
  language/stopWords changes as "reindex needed" for Azure indexes was a
  false positive — reindexing did nothing, and the edit UI let users set
  stop words that were silently ignored. Now only Elasticsearch indexes
  track those fields for reindex purposes, the UI hides the now-inapplicable
  cards for other providers, and the docs call out the same
  Elasticsearch-only limitation already documented for Language.
- recreateEmptyIndex rebuilds the index from current DB settings but never
  cleared requiresReindex, so the UI kept showing "reindex needed" after a
  successful recreate. It now calls markMappingSynced() like the real
  reindex path does.
