### PR TITLE
fix: stem synonym search analyzers per language & only bind numeric c…

### DIFF
--- a/backend/src/app/api/v1/search/[slug]/summarize/route.ts
+++ b/backend/src/app/api/v1/search/[slug]/summarize/route.ts
@@ -17,7 +17,7 @@ import * as aiService from '@/features/ai-service/ai-service.service';
 import type { ChatMessage } from '@/features/ai-service/ai-service.types';
 import * as repository from '@/features/search-experience/search-experience.repository';
 import { summarizeAPIRequestSchema } from '@/features/search-experience/search-experience.schemas';
-import { buildSummarySystemPrompt } from '@/features/chat/prompt-builder';
+import { buildSummarySystemPrompt, formatFieldsForContext } from '@/features/chat/prompt-builder';
 
 const logger = createLogger('summarize-api-slug');
 
@@ -213,42 +213,3 @@ function buildSummaryUserPromptLocal(
   return prompt;
 }
 
-/**
- * Format all fields from a result into a readable context string.
- * Uses all fields that were marked as includeInResponse in the data template.
- */
-function formatFieldsForContext(fields: Record<string, unknown>): string {
-  const parts: string[] = [];
-
-  for (const [key, value] of Object.entries(fields)) {
-    // Skip internal/meta fields
-    if (key.startsWith('_')) continue;
-    if (value === null || value === undefined || value === '') continue;
-
-    // Format the value
-    let formattedValue: string;
-    if (Array.isArray(value)) {
-      formattedValue = value.join(', ');
-    } else if (typeof value === 'object') {
-      formattedValue = JSON.stringify(value);
-    } else {
-      formattedValue = String(value);
-    }
-
-    // Truncate very long values
-    if (formattedValue.length > 500) {
-      formattedValue = formattedValue.substring(0, 500) + '...';
-    }
-
-    // Use readable field name (convert camelCase/snake_case to Title Case)
-    const readableKey = key
-      .replace(/([A-Z])/g, ' $1')
-      .replace(/_/g, ' ')
-      .replace(/^\w/, (c) => c.toUpperCase())
-      .trim();
-
-    parts.push(`${readableKey}: ${formattedValue}`);
-  }
-
-  return parts.join('\n');
-}

--- a/backend/src/features/chat/chat.api.handlers.ts
+++ b/backend/src/features/chat/chat.api.handlers.ts
@@ -28,10 +28,7 @@ import type {
   ChatStreamEvent,
   DocumentReference,
 } from '@/features/search-experience/search-experience.types';
-import { buildSummarySystemPrompt } from '@/features/chat/prompt-builder';
-import {
-  truncateText,
-} from '@/features/chat/chat.utils';
+import { buildSummarySystemPrompt, formatFieldsForContext } from '@/features/chat/prompt-builder';
 
 const logger = createLogger('search-experience-ai');
 
@@ -219,8 +216,8 @@ function buildSummaryUserPrompt(
   const resultsText = results
     .map((r, i) => {
       const title = r.fields.title || r.fields.name || `Item ${i + 1}`;
-      const content = r.fields.content || r.fields.description || r.fields.body || '';
-      return `[${i + 1}] ${title}\n${truncateText(String(content), 500)}`;
+      const details = formatFieldsForContext(r.fields);
+      return `[${i + 1}] ${title}${details ? `\n${details}` : ''}`;
     })
     .join('\n\n---\n\n');
 

--- a/backend/src/features/chat/prompt-builder.test.ts
+++ b/backend/src/features/chat/prompt-builder.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+
+import { formatFieldsForContext } from './prompt-builder';
+
+describe('formatFieldsForContext — giving the summarizer real data to work with', () => {
+    it('includes fields beyond title/content, like material', () => {
+        // The bug this guards: a summarizer that only ever sees title/content
+        // can't say anything about a product whose relevant data lives under a
+        // different key, and will (correctly, per its own instructions) claim
+        // that attribute doesn't exist.
+        const result = formatFieldsForContext({
+            name: 'Anchor & Pine Classic Casual Shirt',
+            material: '100% cotton',
+        });
+
+        expect(result).toContain('Material: 100% cotton');
+    });
+
+    it('skips internal/meta fields prefixed with _', () => {
+        const result = formatFieldsForContext({
+            name: 'Test Product',
+            _score: 12.3,
+            _internalId: 'abc',
+        });
+
+        expect(result).not.toContain('_score');
+        expect(result).not.toContain('_internalId');
+    });
+
+    it('skips null, undefined, and empty-string values', () => {
+        const result = formatFieldsForContext({
+            name: 'Test Product',
+            description: null,
+            brand: undefined,
+            color: '',
+        });
+
+        expect(result).toBe('Name: Test Product');
+    });
+
+    it('truncates values over 500 characters', () => {
+        const longText = 'x'.repeat(600);
+
+        const result = formatFieldsForContext({ description: longText });
+
+        expect(result).toBe(`Description: ${'x'.repeat(500)}...`);
+    });
+
+    it('formats camelCase and snake_case keys as readable Title Case labels', () => {
+        const result = formatFieldsForContext({
+            primaryColor: 'Blue',
+            available_sizes: 'S, M, L',
+        });
+
+        expect(result).toContain('Primary Color: Blue');
+        expect(result).toContain('Available sizes: S, M, L');
+    });
+
+    it('joins array values with commas', () => {
+        const result = formatFieldsForContext({ tags: ['casual', 'summer', 'cotton'] });
+
+        expect(result).toBe('Tags: casual, summer, cotton');
+    });
+});

--- a/backend/src/features/chat/prompt-builder.ts
+++ b/backend/src/features/chat/prompt-builder.ts
@@ -192,6 +192,52 @@ export function buildSummarySystemPrompt(options: BuildSummaryPromptOptions): st
   return parts.join('\n\n');
 }
 
+/**
+ * Format all fields from a result into a readable context string, for
+ * inclusion in a summary prompt.
+ *
+ * Iterates every field rather than a fixed allowlist — a summarizer that only
+ * ever sees `title`/`content`-shaped fields can't say anything about a result
+ * whose relevant data lives under a different key (e.g. a product's
+ * `material`), and will (correctly, per its own "don't claim what isn't in
+ * the data" instructions) claim that attribute doesn't exist.
+ */
+export function formatFieldsForContext(fields: Record<string, unknown>): string {
+  const parts: string[] = [];
+
+  for (const [key, value] of Object.entries(fields)) {
+    // Skip internal/meta fields
+    if (key.startsWith('_')) continue;
+    if (value === null || value === undefined || value === '') continue;
+
+    // Format the value
+    let formattedValue: string;
+    if (Array.isArray(value)) {
+      formattedValue = value.join(', ');
+    } else if (typeof value === 'object') {
+      formattedValue = JSON.stringify(value);
+    } else {
+      formattedValue = String(value);
+    }
+
+    // Truncate very long values
+    if (formattedValue.length > 500) {
+      formattedValue = formattedValue.substring(0, 500) + '...';
+    }
+
+    // Use readable field name (convert camelCase/snake_case to Title Case)
+    const readableKey = key
+      .replace(/([A-Z])/g, ' $1')
+      .replace(/_/g, ' ')
+      .replace(/^\w/, (c) => c.toUpperCase())
+      .trim();
+
+    parts.push(`${readableKey}: ${formattedValue}`);
+  }
+
+  return parts.join('\n');
+}
+
 // ============================================================================
 // EXPORTS FOR TESTING/INSPECTION
 // ============================================================================

--- a/backend/src/features/chat/prompts/summary-system.md
+++ b/backend/src/features/chat/prompts/summary-system.md
@@ -20,3 +20,8 @@ CRITICAL: Only describe attributes that are explicitly present in the result dat
 - If results are related but don't exactly match the query criteria, be honest: "While I didn't find exact matches for [specific criteria], here are some related options"
 - Only state colors, materials, categories, or other attributes if they appear in the actual data fields
 - Never assume or infer attributes based solely on the search query - verify against the actual field values
+
+## Numeric and Threshold Criteria
+
+- When the user's question is a numeric threshold or comparison (e.g. "more than 50% cotton", "under $50", "at least 4 stars"), actually evaluate the field's stated value against that threshold — this is a comparison to work out, not a literal string to match.
+- If a field's stated value satisfies the threshold (material "97% cotton, 3% elastane" satisfies "more than 50% cotton"), say so plainly and confidently. Do not fall back to "I didn't find exact matches" language for a result that numerically qualifies — that phrasing is for when the data genuinely doesn't support the claim, not for every non-literal match.

--- a/backend/src/features/pipeline/v2/action-steps/result-capture.step.test.ts
+++ b/backend/src/features/pipeline/v2/action-steps/result-capture.step.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+
+import { ResultCaptureStep, _buildSnapshot } from './result-capture.step';
+
+import type { ActionStepContext, ActionStepDeps } from './action-step.types';
+import type { ToolExecutionResultV2 } from '../v2.types';
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+/**
+ * Build a context around one tool result — only the fields this step actually
+ * reads (`toolResult`, `action.toolSlug`, `turnContext.resultMemory*`) matter.
+ */
+function context(toolResult: ToolExecutionResultV2 | null): ActionStepContext {
+    return {
+        action: { toolSlug: 'catalog-find', intent: 'look up item' },
+        toolResult,
+        turnContext: {
+            resultMemory: { sets: {} },
+            resultMemoryIndex: [],
+        },
+    } as unknown as ActionStepContext;
+}
+
+const deps = {} as ActionStepDeps;
+
+// ============================================================================
+// TESTS
+// ============================================================================
+
+describe('ResultCaptureStep — remembering what a tool just found', () => {
+    it('indexes a single-record lookup result ({ id, document }), not just arrays', () => {
+        // The "find record" tool never returns an array or a `.results` list —
+        // without this, a correct, specific lookup was silently dropped from
+        // result memory, and the next turn had no durable id to reference.
+        const step = new ResultCaptureStep();
+        const ctx = context({
+            success: true,
+            resultCount: 1,
+            data: {
+                id: 'prod_01ABC',
+                document: { name: 'Skyline Fashion Vintage Silk Shirt', price: 151.11 },
+            },
+        });
+
+        return step.execute(ctx, deps).then((result) => {
+            expect(result.context.turnContext.resultMemoryIndex).toHaveLength(1);
+            expect(result.context.turnContext.resultMemoryIndex[0]).toMatchObject({
+                resultId: 'prod_01ABC',
+                snapshot: expect.objectContaining({ name: 'Skyline Fashion Vintage Silk Shirt' }),
+            });
+            expect(result.context.turnContext.resultMemory.sets['catalog-find'].totalCount).toBe(1);
+        });
+    });
+
+    it('still indexes array-shaped results unchanged', async () => {
+        const step = new ResultCaptureStep();
+        const ctx = context({
+            success: true,
+            resultCount: 2,
+            data: [{ id: 'a' }, { id: 'b' }],
+        });
+
+        const result = await step.execute(ctx, deps);
+
+        expect(result.context.turnContext.resultMemoryIndex).toHaveLength(2);
+    });
+
+    it('still indexes `.results`-shaped results unchanged', async () => {
+        const step = new ResultCaptureStep();
+        const ctx = context({
+            success: true,
+            resultCount: 3,
+            data: { results: [{ id: 'a' }, { id: 'b' }, { id: 'c' }] },
+        });
+
+        const result = await step.execute(ctx, deps);
+
+        expect(result.context.turnContext.resultMemoryIndex).toHaveLength(3);
+    });
+
+    it('does not index a plain object with no id (not a lookup result)', async () => {
+        const step = new ResultCaptureStep();
+        const ctx = context({
+            success: true,
+            resultCount: 0,
+            data: { message: 'no id here' },
+        });
+
+        const result = await step.execute(ctx, deps);
+
+        // Untouched — no results to index, prior index (empty) stands.
+        expect(result.context.turnContext.resultMemoryIndex).toHaveLength(0);
+    });
+
+    it('skips capture entirely when the tool failed or returned nothing', async () => {
+        const step = new ResultCaptureStep();
+        const ctx = context({ success: false, resultCount: 0, data: null });
+
+        const result = await step.execute(ctx, deps);
+
+        expect(result.summary).toBe('No results to capture');
+        expect(result.context.turnContext.resultMemoryIndex).toHaveLength(0);
+    });
+});
+
+describe('_buildSnapshot — already handles the lookup shape', () => {
+    it('reads display fields out of a nested `document`', () => {
+        const snapshot = _buildSnapshot({
+            id: 'prod_01ABC',
+            document: { name: 'Skyline Fashion Vintage Silk Shirt', price: 151.11 },
+        });
+
+        expect(snapshot).toMatchObject({
+            id: 'prod_01ABC',
+            name: 'Skyline Fashion Vintage Silk Shirt',
+            price: 151.11,
+        });
+    });
+});

--- a/backend/src/features/pipeline/v2/action-steps/result-capture.step.ts
+++ b/backend/src/features/pipeline/v2/action-steps/result-capture.step.ts
@@ -30,7 +30,16 @@ export class ResultCaptureStep implements ActionStep {
     }
 
     const data = ctx.toolResult.data;
-    const rawItems = Array.isArray(data) ? data : (data as Record<string, unknown>)?.results ?? [];
+    // A lookup/"find record" tool returns a single `{ id, document }` object,
+    // not an array or a `.results` list. Without this, a correct, specific
+    // lookup is silently dropped from result memory — the next turn has no
+    // durable reference to "which item" and has to re-resolve it by fuzzy
+    // name search, which is why losing track of the item looks intermittent
+    // rather than a hard failure.
+    const rawItems = Array.isArray(data)
+      ? data
+      : (data as Record<string, unknown>)?.results ??
+        (data && typeof data === 'object' && 'id' in data ? [data] : []);
     const items = Array.isArray(rawItems) ? rawItems : [];
     const resultCount = ctx.toolResult.resultCount ?? items.length;
 

--- a/backend/src/features/pipeline/v2/param-validation.test.ts
+++ b/backend/src/features/pipeline/v2/param-validation.test.ts
@@ -11,11 +11,13 @@ vi.mock('@/shared/logger/logger', () => ({
 
 import {
   validateParameters,
+  validateFilters,
   _fuzzyMatchEnum,
   _levenshteinDistance,
 } from './param-validation';
 import type { ParamValidationInput } from './v2.types';
 import type { ToolParameterSchema } from '@/features/ai-service/ai-service.types';
+import type { FieldConstraint, ParameterContext } from './parameter-context.types';
 
 // ============================================================================
 // FIXTURES
@@ -37,6 +39,26 @@ function makeInput(
   schema: ToolParameterSchema = SEARCH_SCHEMA,
 ): ParamValidationInput {
   return { parameters: params, inputSchema: schema };
+}
+
+function makeConstraint(overrides: Partial<FieldConstraint>): FieldConstraint {
+  return {
+    fieldName: 'field',
+    fieldType: 'text',
+    isFilterable: true,
+    isFacetable: false,
+    validValues: [],
+    ...overrides,
+  };
+}
+
+function makeContext(fieldConstraints: Record<string, FieldConstraint>): ParameterContext {
+  return {
+    fieldConstraints,
+    enriched: true,
+    summary: 'test context',
+    durationMs: 0,
+  };
 }
 
 // ============================================================================
@@ -304,6 +326,98 @@ describe('D2b: Parameter Validation', () => {
     it('includes summary with error fields', () => {
       const result = validateParameters(makeInput({}));
       expect(result.summary).toContain('query');
+    });
+  });
+
+  describe('validateFilters — range operators vs field type', () => {
+    it('drops a gte filter against a text field (e.g. "material >= 80")', () => {
+      const context = makeContext({
+        material: makeConstraint({
+          fieldName: 'material',
+          fieldType: 'text',
+          isFacetable: true,
+          validValues: ['80% cotton, 18% polyester, 2% elastane', '97% cotton, 3% elastane'],
+        }),
+      });
+
+      const result = validateFilters(
+        [{ field: 'material', operator: 'gte', value: '80' }],
+        context,
+      );
+
+      expect(result.filters).toHaveLength(0);
+      expect(result.droppedFilters).toHaveLength(1);
+      expect(result.droppedFilters[0]).toMatchObject({
+        field: 'material',
+        originalValue: '80',
+      });
+      expect(result.droppedFilters[0].reason).toContain('gte');
+      expect(result.droppedFilters[0].reason).toContain('text');
+      expect(result.hasCorrections).toBe(true);
+    });
+
+    it.each(['gt', 'gte', 'lt', 'lte'])('drops a %s filter against a boolean field', (operator) => {
+      const context = makeContext({
+        inStock: makeConstraint({ fieldName: 'inStock', fieldType: 'boolean' }),
+      });
+
+      const result = validateFilters(
+        [{ field: 'inStock', operator, value: true }],
+        context,
+      );
+
+      expect(result.filters).toHaveLength(0);
+      expect(result.droppedFilters).toHaveLength(1);
+    });
+
+    it('keeps a gte filter against a number field', () => {
+      const context = makeContext({
+        minPrice: makeConstraint({ fieldName: 'minPrice', fieldType: 'number' }),
+      });
+
+      const result = validateFilters(
+        [{ field: 'minPrice', operator: 'gte', value: 50 }],
+        context,
+      );
+
+      expect(result.filters).toEqual([{ field: 'minPrice', operator: 'gte', value: 50 }]);
+      expect(result.droppedFilters).toHaveLength(0);
+      expect(result.hasCorrections).toBe(false);
+    });
+
+    it('keeps a lte filter against a date field', () => {
+      const context = makeContext({
+        createdAt: makeConstraint({ fieldName: 'createdAt', fieldType: 'date' }),
+      });
+
+      const result = validateFilters(
+        [{ field: 'createdAt', operator: 'lte', value: '2026-01-01' }],
+        context,
+      );
+
+      expect(result.filters).toEqual([
+        { field: 'createdAt', operator: 'lte', value: '2026-01-01' },
+      ]);
+      expect(result.droppedFilters).toHaveLength(0);
+    });
+
+    it('still canonicalizes eq filter values against a text field (unaffected by the new check)', () => {
+      const context = makeContext({
+        category: makeConstraint({
+          fieldName: 'category',
+          fieldType: 'text',
+          isFacetable: true,
+          validValues: ['Jeans', 'Trousers'],
+        }),
+      });
+
+      const result = validateFilters(
+        [{ field: 'category', operator: 'eq', value: 'jeans' }],
+        context,
+      );
+
+      expect(result.filters).toEqual([{ field: 'category', operator: 'eq', value: 'Jeans' }]);
+      expect(result.hasCorrections).toBe(true);
     });
   });
 });

--- a/backend/src/features/pipeline/v2/param-validation.ts
+++ b/backend/src/features/pipeline/v2/param-validation.ts
@@ -385,17 +385,25 @@ function levenshteinDistance(a: string, b: string): number {
 
 import type { ParameterContext, FilterValidationResult } from './parameter-context.types';
 
+const RANGE_OPERATORS = new Set(['gt', 'gte', 'lt', 'lte']);
+const RANGE_CAPABLE_FIELD_TYPES = new Set(['number', 'date']);
+
 /**
  * Validate and correct extracted filter parameters using the enriched
  * parameter context (field constraints with known valid values).
  *
  * Checks for each filter:
  * 1. Is the field isFilterable? → if not, drop it
- * 2. Is it a text field with known valid values (isFacetable)?
+ * 2. Is it a range operator (gt/gte/lt/lte) against a non-numeric/date field?
+ *    → drop it. A relational comparison against a `text`/`boolean` field isn't
+ *      meaningful — e.g. "material >= 80" against a free-text composition
+ *      sentence like "80% cotton, 18% polyester" answers nothing, and
+ *      Elasticsearch range queries on analyzed text fields fail or misbehave.
+ * 3. Is it a text field with known valid values (isFacetable)?
  *    → verify the value exists in valid values (case-insensitive + substring match)
  *    → if no match, drop the filter and record the reason
- * 3. Is it a numeric/boolean field? → pass through (type coercion handled by validateParameters)
- * 4. Is it filterable but NOT facetable? → pass through (can't verify, search provider handles it)
+ * 4. Is it a numeric/boolean field? → pass through (type coercion handled by validateParameters)
+ * 5. Is it filterable but NOT facetable? → pass through (can't verify, search provider handles it)
  */
 export function validateFilters(
   filters: Array<{ field: string; operator: string; value: unknown }>,
@@ -439,7 +447,18 @@ export function validateFilters(
       continue;
     }
 
-    // Check 2: For text fields with known valid values, verify the value
+    // Check 2: Range operators only make sense on numeric/date fields
+    if (RANGE_OPERATORS.has(filter.operator) && !RANGE_CAPABLE_FIELD_TYPES.has(constraint.fieldType)) {
+      droppedFilters.push({
+        field: filter.field,
+        reason: `Range operator "${filter.operator}" is not supported on field type "${constraint.fieldType}"`,
+        originalValue: filter.value,
+      });
+      hasCorrections = true;
+      continue;
+    }
+
+    // Check 3: For text fields with known valid values, verify the value
     if (constraint.fieldType === 'text' && constraint.validValues.length > 0) {
       const filterValue = String(filter.value);
       const matchedValue = matchFilterValue(filterValue, constraint.validValues);

--- a/backend/src/features/search-experience/query-interpreter.core.ts
+++ b/backend/src/features/search-experience/query-interpreter.core.ts
@@ -8,6 +8,12 @@
  *   "show only items from the men T-shirt below $110"
  *     → query "t-shirt", filters gender=Men, minPrice<=110
  *
+ *   "pants with more than 80% cotton"
+ *     → query "pants", filters: none (material is a text field enumerating whole
+ *       composition sentences like "97% cotton, 3% elastane", not a numeric percentage
+ *       — there is no field to bind ">80%" to, so the comparison stays in the query text
+ *       rather than becoming a false `material` filter snapped to the nearest value)
+ *
  * Without this, a search box can only ever match those words as text — "$110" is
  * a token to match, not a number to compare — so a price or gender phrase silently
  * does nothing.
@@ -122,7 +128,15 @@ ${describeFields(constraints)}
    - "between $X and $Y" → minPrice <= Y and maxPrice >= X.
    - If only one of the pair is filterable, use that one rather than skipping the filter.
 6. If the phrase carries no structured constraint at all, return it as the query with
-   an empty filters array. Do not force a filter that was not asked for.`;
+   an empty filters array. Do not force a filter that was not asked for.
+7. Comparison language ("more than", "at least", "over", "under", "at most", "below")
+   states a numeric threshold. Only turn it into a gt/gte/lt/lte filter on a field
+   that is genuinely numeric. Never snap it onto a text field's valid-value list by
+   picking the closest-sounding entry — e.g. "more than 80% cotton" against a
+   material field whose values are whole composition sentences ("97% cotton, 3%
+   elastane") is not the same claim as "material is 100% cotton", and forcing that
+   match changes what the shopper asked for. When no field can express the
+   threshold, leave that part of the phrase in the query instead.`;
 
     if (customInstructions) {
         prompt += `\n\n## Additional instructions\n${customInstructions}`;

--- a/backend/src/features/search/providers/elasticsearch/elasticsearch-engine.provider.ts
+++ b/backend/src/features/search/providers/elasticsearch/elasticsearch-engine.provider.ts
@@ -305,17 +305,14 @@ export class ElasticsearchEngineProvider implements SearchEngineProvider {
         if (synonymRules.length > 0) {
             const synonymAnalyzer = { type: 'custom', tokenizer: 'standard', filter: ['lowercase', 'interakt_synonyms'] };
             const existing = (indexSettings.analysis as Record<string, unknown> | undefined) ?? {};
-            indexSettings.analysis = {
-                ...existing,
-                filter: {
-                    ...(existing.filter as Record<string, unknown> | undefined),
-                    interakt_synonyms: { type: 'synonym_graph', synonyms: synonymRules, lenient: true },
-                },
-                analyzer: {
-                    ...(existing.analyzer as Record<string, unknown> | undefined),
-                    interakt_synonym_search: synonymAnalyzer,
-                    default_search: synonymAnalyzer,
-                },
+            const analyzers: Record<string, unknown> = {
+                ...(existing.analyzer as Record<string, unknown> | undefined),
+                interakt_synonym_search: synonymAnalyzer,
+                default_search: synonymAnalyzer,
+            };
+            const filters: Record<string, unknown> = {
+                ...(existing.filter as Record<string, unknown> | undefined),
+                interakt_synonyms: { type: 'synonym_graph', synonyms: synonymRules, lenient: true },
             };
 
             // Attach to searchable text fields, skipping autocomplete fields (which keep
@@ -326,10 +323,40 @@ export class ElasticsearchEngineProvider implements SearchEngineProvider {
             for (const f of context.fields) {
                 if (!f.isSearchable || autocompleteNames.has(f.fieldName)) continue;
                 const prop = properties[f.fieldName] as Record<string, unknown> | undefined;
-                if (prop && prop.type === 'text' && prop.search_analyzer === undefined) {
+                if (!prop || prop.type !== 'text' || prop.search_analyzer !== undefined) continue;
+
+                // A field indexed with an ES language analyzer (e.g. "english") stems its
+                // tokens at write time. Searching it with the plain synonym analyzer above
+                // (no stemmer) would then compare stemmed index tokens against unstemmed
+                // query tokens and silently under-match — "jackets" never finding documents
+                // that were indexed down to the stemmed "jacket". Give each such field a
+                // synonym analyzer that stems the same way, so index- and search-time
+                // tokens agree. `language` reuses the field's own `customAnalyzer` value —
+                // ES's `stop`/`stemmer` filters accept the same language names as its
+                // built-in language analyzers (see ES_LANGUAGES), so no translation needed.
+                const rawAnalyzer = f.providerFieldSettings?.customAnalyzer as string | null | undefined;
+                const language =
+                    rawAnalyzer && rawAnalyzer !== 'standard' && rawAnalyzer !== 'autocomplete'
+                        ? rawAnalyzer
+                        : undefined;
+                if (language) {
+                    const analyzerName = `interakt_synonym_search_${language}`;
+                    if (!analyzers[analyzerName]) {
+                        analyzers[analyzerName] = {
+                            type: 'custom',
+                            tokenizer: 'standard',
+                            filter: ['lowercase', 'interakt_synonyms', `${language}_stop`, `${language}_stemmer`],
+                        };
+                        filters[`${language}_stop`] = { type: 'stop', stopwords: `_${language}_` };
+                        filters[`${language}_stemmer`] = { type: 'stemmer', language };
+                    }
+                    prop.search_analyzer = analyzerName;
+                } else {
                     prop.search_analyzer = 'interakt_synonym_search';
                 }
             }
+
+            indexSettings.analysis = { ...existing, filter: filters, analyzer: analyzers };
         }
 
         // Extract ES-specific settings from providerSettings

--- a/backend/src/features/search/providers/elasticsearch/query-builders/filter.builder.ts
+++ b/backend/src/features/search/providers/elasticsearch/query-builders/filter.builder.ts
@@ -193,16 +193,16 @@ export function buildOperatorQuery(
             return buildNeqQuery(keywordField, value);
 
         case 'gt':
-            return buildRangeQuery(field, { gt: value as number | string });
+            return buildRangeQuery(keywordField, { gt: value as number | string });
 
         case 'gte':
-            return buildRangeQuery(field, { gte: value as number | string });
+            return buildRangeQuery(keywordField, { gte: value as number | string });
 
         case 'lt':
-            return buildRangeQuery(field, { lt: value as number | string });
+            return buildRangeQuery(keywordField, { lt: value as number | string });
 
         case 'lte':
-            return buildRangeQuery(field, { lte: value as number | string });
+            return buildRangeQuery(keywordField, { lte: value as number | string });
 
         case 'in':
             return buildInQuery(keywordField, value);


### PR DESCRIPTION
fix: only bind numeric comparisons to numeric fields, not text-field values
fix: stem synonym search analyzers per language (e.g. "jackets" matches indexed "jacket")