### PR TITLE
fix: normalize unsigned_long and token_count as numeric field types

### DIFF
--- a/backend/src/features/data-source/data-source.service.ts
+++ b/backend/src/features/data-source/data-source.service.ts
@@ -986,6 +986,6 @@ export async function isSlugAvailable(slug: string, excludeId?: string) {
   return repository.isSlugAvailable(slug, excludeId);
 }
 
-// Exported for tests only — the provider type maps are pure and worth pinning
-// directly, since their output is persisted onto the data source record.
-export { mapESType as _mapESType, mapAzureType as _mapAzureType };
+// Exported for tests only — mapESType is pure and worth pinning directly,
+// since its output is persisted onto the data source record.
+export { mapESType as _mapESType };

--- a/backend/src/features/data-source/data-source.service.ts
+++ b/backend/src/features/data-source/data-source.service.ts
@@ -813,6 +813,8 @@ function mapESType(esType?: string): string {
     case 'long':
     case 'short':
     case 'byte':
+    case 'unsigned_long':
+    case 'token_count':
       return 'number';
     case 'float':
     case 'double':
@@ -983,3 +985,7 @@ function mapAzureType(azureType: string): string {
 export async function isSlugAvailable(slug: string, excludeId?: string) {
   return repository.isSlugAvailable(slug, excludeId);
 }
+
+// Exported for tests only — the provider type maps are pure and worth pinning
+// directly, since their output is persisted onto the data source record.
+export { mapESType as _mapESType, mapAzureType as _mapAzureType };

--- a/backend/src/features/data-source/field-type-normalization.test.ts
+++ b/backend/src/features/data-source/field-type-normalization.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Numeric field types must survive both normalization hops.
+ *
+ * An external data source field passes through two independent switches before
+ * anything uses its type: `mapESType` at discovery, whose result is PERSISTED
+ * onto the data source record, and `normalizeFieldType` when the parameter
+ * context is assembled. Both end in a default that yields `text`, so a numeric
+ * spelling missing from either list is treated as free text from then on:
+ *
+ *   1. it is picked up as a "facetable text field" and its values are
+ *      enumerated into the extraction prompt as a filter vocabulary, and
+ *   2. `validateFilters` then requires a filter value to match one of those
+ *      enumerated values, dropping the filter when it doesn't.
+ *
+ * Both hops are pinned here because fixing only discovery leaves every already
+ * discovered data source broken until someone re-runs discovery.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@/shared/logger/logger', () => {
+  const mk: any = () => ({
+    debug: () => {}, info: () => {}, warn: () => {}, error: () => {}, trace: () => {}, child: mk,
+  });
+  return { logger: mk(), createLogger: mk, default: mk() };
+});
+
+import { _mapESType } from './data-source.service';
+import { _DataSourceSearchProvider } from '@/features/pipeline/v2/parameter-context.provider';
+import type { FieldConstraint } from '@/features/pipeline/v2/parameter-context.types';
+
+const normalize = (t: string): FieldConstraint['fieldType'] =>
+  // normalizeFieldType is private; TS access modifiers are compile-time only.
+  (new _DataSourceSearchProvider() as unknown as {
+    normalizeFieldType(t: string): FieldConstraint['fieldType'];
+  }).normalizeFieldType(t);
+
+/** Every scalar numeric field type Elasticsearch supports. */
+const ES_NUMERIC_TYPES = [
+  'long', 'integer', 'short', 'byte',
+  'double', 'float', 'half_float', 'scaled_float',
+  'unsigned_long', 'token_count',
+];
+
+describe('numeric field type normalization', () => {
+  describe('mapESType — at discovery; the result is persisted', () => {
+    it.each(ES_NUMERIC_TYPES)('maps %s to number', (esType) => {
+      expect(_mapESType(esType)).toBe('number');
+    });
+
+    it('leaves the non-numeric mappings as they were', () => {
+      expect(_mapESType('text')).toBe('text');
+      expect(_mapESType('keyword')).toBe('text');
+      expect(_mapESType('search_as_you_type')).toBe('text');
+      expect(_mapESType('boolean')).toBe('boolean');
+      expect(_mapESType('date')).toBe('date');
+      expect(_mapESType('date_nanos')).toBe('date');
+      expect(_mapESType('geo_point')).toBe('geo');
+      expect(_mapESType('geo_shape')).toBe('geo');
+    });
+
+    it('keeps a genuinely unknown type recognizable instead of guessing', () => {
+      expect(_mapESType('some_future_type')).toBe('some_future_type');
+      expect(_mapESType(undefined)).toBe('unknown');
+    });
+  });
+
+  describe('normalizeFieldType — runs against the persisted type', () => {
+    it.each(ES_NUMERIC_TYPES)('maps a persisted %s to number', (esType) => {
+      expect(normalize(esType)).toBe('number');
+    });
+
+    it('maps the Azure Edm numerics to number', () => {
+      for (const t of ['Edm.Int32', 'Edm.Int64', 'Edm.Double']) {
+        expect(normalize(t)).toBe('number');
+      }
+    });
+
+    it('maps every date spelling to date', () => {
+      for (const t of ['date', 'datetime', 'date_nanos', 'Edm.DateTimeOffset']) {
+        expect(normalize(t)).toBe('date');
+      }
+    });
+
+    it('maps booleans to boolean', () => {
+      expect(normalize('boolean')).toBe('boolean');
+      expect(normalize('Edm.Boolean')).toBe('boolean');
+    });
+
+    it('still falls back to text for genuinely non-numeric types', () => {
+      for (const t of ['text', 'keyword', 'geo', 'ip', 'some_future_type']) {
+        expect(normalize(t)).toBe('text');
+      }
+    });
+  });
+
+  describe('consequence: a numeric field is not mistaken for a filter vocabulary', () => {
+    // Mirrors the predicate the provider uses to choose fields for facet
+    // enumeration: isFilterable && isFacetable && normalized type === 'text'.
+    const wouldEnumerate = (esType: string): boolean =>
+      normalize(_mapESType(esType)) === 'text';
+
+    it.each(ES_NUMERIC_TYPES)('does not enumerate facet values for an %s field', (esType) => {
+      expect(wouldEnumerate(esType)).toBe(false);
+    });
+
+    it('still enumerates a real text field', () => {
+      expect(wouldEnumerate('keyword')).toBe(true);
+      expect(wouldEnumerate('text')).toBe(true);
+    });
+  });
+});

--- a/backend/src/features/data-source/field-type-normalization.test.ts
+++ b/backend/src/features/data-source/field-type-normalization.test.ts
@@ -26,7 +26,11 @@ vi.mock('@/shared/logger/logger', () => {
 
 import { _mapESType } from './data-source.service';
 import { _DataSourceSearchProvider } from '@/features/pipeline/v2/parameter-context.provider';
-import type { FieldConstraint } from '@/features/pipeline/v2/parameter-context.types';
+import { validateFilters } from '@/features/pipeline/v2/param-validation';
+import type {
+  FieldConstraint,
+  ParameterContext,
+} from '@/features/pipeline/v2/parameter-context.types';
 
 const normalize = (t: string): FieldConstraint['fieldType'] =>
   // normalizeFieldType is private; TS access modifiers are compile-time only.
@@ -93,19 +97,44 @@ describe('numeric field type normalization', () => {
     });
   });
 
-  describe('consequence: a numeric field is not mistaken for a filter vocabulary', () => {
-    // Mirrors the predicate the provider uses to choose fields for facet
-    // enumeration: isFilterable && isFacetable && normalized type === 'text'.
-    const wouldEnumerate = (esType: string): boolean =>
-      normalize(_mapESType(esType)) === 'text';
-
-    it.each(ES_NUMERIC_TYPES)('does not enumerate facet values for an %s field', (esType) => {
-      expect(wouldEnumerate(esType)).toBe(false);
+  describe('consequence: the filter survives instead of being dropped', () => {
+    // Exercises the real check #42 added: validateFilters drops gt/gte/lt/lte
+    // against any field whose constraint type is not number or date.
+    const contextFor = (esType: string): ParameterContext => ({
+      fieldConstraints: {
+        popularity: {
+          fieldName: 'popularity',
+          fieldType: normalize(_mapESType(esType)),
+          isFilterable: true,
+          isFacetable: false,
+          validValues: [],
+        },
+      },
+      enriched: true,
+      summary: '',
+      durationMs: 0,
     });
 
-    it('still enumerates a real text field', () => {
-      expect(wouldEnumerate('keyword')).toBe(true);
-      expect(wouldEnumerate('text')).toBe(true);
+    it.each(ES_NUMERIC_TYPES)('keeps "popularity >= 100" on an %s field', (esType) => {
+      const result = validateFilters(
+        [{ field: 'popularity', operator: 'gte', value: 100 }],
+        contextFor(esType),
+      );
+
+      expect(result.droppedFilters).toEqual([]);
+      expect(result.filters).toEqual([
+        { field: 'popularity', operator: 'gte', value: 100 },
+      ]);
+    });
+
+    it('still drops a range filter on a genuinely textual field', () => {
+      const result = validateFilters(
+        [{ field: 'popularity', operator: 'gte', value: 100 }],
+        contextFor('keyword'),
+      );
+
+      expect(result.filters).toEqual([]);
+      expect(result.droppedFilters).toHaveLength(1);
     });
   });
 });

--- a/backend/src/features/pipeline/v2/parameter-context.provider.ts
+++ b/backend/src/features/pipeline/v2/parameter-context.provider.ts
@@ -298,12 +298,25 @@ class DataSourceSearchProvider implements ParameterContextProvider {
       case 'edm.int32':
       case 'edm.int64':
       case 'edm.double':
+      // Spellings `mapESType` passes through untouched, so they can reach here
+      // verbatim from a persisted schema. Missing one means the field is read as
+      // free text: enumerated as a filter vocabulary, and its filters then
+      // dropped for not matching one of the enumerated values.
+      case 'short':
+      case 'byte':
+      case 'half_float':
+      case 'scaled_float':
+      case 'unsigned_long':
+      case 'token_count':
+      case 'decimal':
         return 'number';
       case 'boolean':
       case 'edm.boolean':
         return 'boolean';
       case 'date':
       case 'datetime':
+      case 'date_nanos':
+      case 'timestamp':
       case 'edm.datetimeoffset':
         return 'date';
       default:

--- a/backend/src/features/pipeline/v2/parameter-context.provider.ts
+++ b/backend/src/features/pipeline/v2/parameter-context.provider.ts
@@ -298,17 +298,18 @@ class DataSourceSearchProvider implements ParameterContextProvider {
       case 'edm.int32':
       case 'edm.int64':
       case 'edm.double':
-      // Spellings `mapESType` passes through untouched, so they can reach here
-      // verbatim from a persisted schema. Missing one means the field is read as
-      // free text: enumerated as a filter vocabulary, and its filters then
-      // dropped for not matching one of the enumerated values.
+      // `unsigned_long` and `token_count` were passed through untouched by
+      // mapESType until recently, so schemas discovered before then hold them
+      // verbatim. The rest are normalized at discovery today and only reach
+      // here from a hand-written schema — `type` is a free-form string an
+      // operator can PUT. Anything read as text is enumerated as a filter
+      // vocabulary, and its filters then dropped for not matching a value in it.
+      case 'unsigned_long':
+      case 'token_count':
       case 'short':
       case 'byte':
       case 'half_float':
       case 'scaled_float':
-      case 'unsigned_long':
-      case 'token_count':
-      case 'decimal':
         return 'number';
       case 'boolean':
       case 'edm.boolean':
@@ -316,7 +317,6 @@ class DataSourceSearchProvider implements ParameterContextProvider {
       case 'date':
       case 'datetime':
       case 'date_nanos':
-      case 'timestamp':
       case 'edm.datetimeoffset':
         return 'date';
       default:


### PR DESCRIPTION
`mapESType` passes `unsigned_long` and `token_count` through as raw strings, and `normalizeFieldType` defaults anything it doesn't recognize to `text`. A filterable field of either type on an external data source is therefore read as free text — picked up for facet enumeration as a filter vocabulary, and its filters then dropped in `validateFilters` for not matching one of the enumerated values.

Fixed at both hops. Discovery persists the type onto the data source record, so fixing only `mapESType` would leave already-discovered sources broken until someone re-ran discovery.

37 tests pin both maps and the resulting behaviour, including the spellings that already worked, so the next type added can't quietly regress them.

Gate: 1041 tests (1004 + 37), 0 lint errors, types clean.

Worth flagging alongside #42: its new range-operator check drops `gt/gte/lt/lte` on any field typed `text`, so once that lands this misnormalization would drop those filters outright instead of merely narrowing them.